### PR TITLE
more release preparation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ builds:
   - darwin
   - linux
   - windows
+  binary: octo
 archive:
   replacements:
     darwin: Darwin

--- a/script/build
+++ b/script/build
@@ -6,4 +6,4 @@ set -e
 # Ensure we're always running from the project root
 cd "$(dirname "$0")/.."
 
-go build -o bin/octo-cli -ldflags "-X main.version=${VERSION:-development}"
+go build -o bin/octo -ldflags "-X main.version=${VERSION:-development}"

--- a/script/latestversion
+++ b/script/latestversion
@@ -1,0 +1,14 @@
+#!/bin/sh
+# returns the semver from the latest tag. Drops the leading v
+# pass --nots to drop the -timestamp at the end
+set -e
+
+cd "$(dirname "$0")/.."
+
+if [ "--nots" == "$1" ]; then
+  git describe --tags --match v*[0-9].*[0-9].*[0-9]* --abbrev=0 \
+   | sed -n 's/v\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p'
+else
+  git describe --tags --match v*[0-9].*[0-9].*[0-9]* --abbrev=0 \
+   | sed -n 's/v\(.*\).*/\1/p'
+fi

--- a/script/newversion
+++ b/script/newversion
@@ -1,0 +1,29 @@
+#!/bin/sh
+# returns the version for a new build
+# with no params, it just uses the current version replacing the timestamp with the latest routes.json update time
+# you can add --patch, --minor or --major to iterate the respective version levels
+set -e
+
+cd "$(dirname "$0")/.."
+
+latest="$(script/latestversion --nots)"
+major="$(echo $latest | cut -d. -f 1)"
+minor="$(echo $latest | cut -d. -f 2)"
+patch="$(echo $latest | cut -d. -f 3)"
+
+if [ "--major" == "$1" ]; then
+  major=$((major + 1))
+  minor=0
+  patch=0
+fi
+
+if [ "--minor" == "$1" ]; then
+  minor=$((minor + 1))
+  patch=0
+fi
+
+if [ "--patch" == "$1" ]; then
+  patch=$((patch + 1))
+fi
+
+echo "$major.$minor.$patch-$(cat routes-last-modified.txt)"


### PR DESCRIPTION
This adds two scripts for managing release versions.   `script/newversion` and `script/latestversion`

Also changing the binary name to octo.

We still need to add a script for creating a release tag and running goreleaser, but I want to do this manually a few times first.