### PR TITLE
fix the dockerfile to point to the right bin after rename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,6 @@ RUN script/build
 # Package
 FROM alpine
 
-COPY --from=octo-cli-build-env /go/src/github.com/octo-cli/octo-cli/bin/octo-cli /bin/octo-cli
+COPY --from=octo-cli-build-env /go/src/github.com/octo-cli/octo-cli/bin/octo /bin/octo
 RUN apk add --no-cache ca-certificates jq
-ENTRYPOINT ["octo-cli"]
+ENTRYPOINT ["octo"]


### PR DESCRIPTION
Fix the Dockerfile after the bin name change. This was failing to build the container since the bin changed from `octo-cli` to `octo`.