### PR TITLE
update vcr tests

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -9,7 +9,7 @@ fail() {
   EXITCODE=1
 }
 echo "running script/test"
-script/test || fail
+script/test -race || fail
 
 echo "running script/golint"
 script/golint || fail

--- a/script/test
+++ b/script/test
@@ -3,4 +3,4 @@
 set -e
 
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
-go test -race ./...
+go test ./... $@

--- a/tests/issues_test.go
+++ b/tests/issues_test.go
@@ -2,14 +2,47 @@ package tests
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/octo-cli/octo-cli/generated"
 	"github.com/stretchr/testify/assert"
+	"os"
 	"testing"
+	"text/tabwriter"
+	"text/template"
 )
 
 func TestIssues(t *testing.T) {
 	t.Run("Create", func(t *testing.T) {
-		stdout, stderr, err := testCmdLine(t, "test_issues_create", &generated.IssuesCmd{},
+		format := `{{.state}} : {{.title}} : {{.body}}`
+		newCmdLine(`issues`,
+			`create`,
+			`--owner=octo-cli-testorg`,
+			`--repo=test-create-issue`,
+			`--title=test this`,
+			`--body=test this body`,
+			`--labels=label1`,
+			`--labels=label2`,
+			`--milestone=1`,
+			`--assignees=octo-cli-testuser`,
+			`--format`, format).
+			test(t, "test_issues_create", "open : test this : test this body\n", "", false)
+
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		format := `{{.state}} : {{.title}} : {{.body}}`
+		newCmdLine(`issues`,
+			`get`,
+			`--owner=octo-cli-testorg`,
+			`--repo=test-create-issue`,
+			`--number=1`,
+			`--format`, format,
+		).test(t, "test_issues_get",  "open : \"test this\" : \"test this body\"\n", "", false)
+	})
+
+	t.Run("play with  output", func(t *testing.T) {
+		// just keeping this here until I put it somewhere else because I don't want to forget how it works.
+		stdout, stderr, err := runCmdLine(t, "test_issues_create", &generated.IssuesCmd{},
 			`create`,
 			`--owner=octo-cli-testorg`,
 			`--repo=test-create-issue`,
@@ -26,9 +59,26 @@ func TestIssues(t *testing.T) {
 		var got map[string]interface{}
 		err = json.Unmarshal(stdout.Bytes(), &got)
 		assert.NoError(t, err)
-		assert.Equal(t, "test this", got["title"])
-		assert.Equal(t, "test this body", got["body"])
-		assert.Len(t, got["labels"], 2)
-		assert.EqualValues(t, 1, got["milestone"].(map[string]interface{})["number"])
+
+		tp, err := template.New("").Funcs(template.FuncMap{"wider": func(a, b interface{}) string { return fmt.Sprintf("%-20s%d", a, b) }}).Parse(`
+	Number	{{.number}}
+	State	{{.state}}
+	Title	{{.title}}
+	User	{{.user.login}}
+	URL	{{.html_url}}
+	CreatedAt	{{.created_at}}
+	UpdatedAt	{{.updated_at}}
+	{{if .labels}}Labels{{range .labels}}	{{.name}}
+	{{end}}{{end}}{{if .milestone}}Milestone	{{.milestone.title}}{{end}}
+	{{if .assignees}}Assignees{{range .assignees}}	{{.login}}
+	{{end}}{{end}}
+	`)
+		assert.NoError(t, err)
+		w := tabwriter.NewWriter(os.Stdout, 8, 8, 8, ' ', 0)
+		err = tp.Execute(w, got)
+		assert.NoError(t, err)
+		err = w.Flush()
+		assert.NoError(t, err)
+
 	})
 }

--- a/tests/testdata/fixtures/test_issues_create.yaml
+++ b/tests/testdata/fixtures/test_issues_create.yaml
@@ -13,30 +13,31 @@ interactions:
     url: https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues
     method: POST
   response:
-    body: '{"url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/6","repository_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue","labels_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/6/labels{/name}","comments_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/6/comments","events_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/6/events","html_url":"https://github.com/octo-cli-testorg/test-create-issue/issues/6","id":375219483,"node_id":"MDU6SXNzdWUzNzUyMTk0ODM=","number":6,"title":"test
+    body: '{"url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/11","repository_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue","labels_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/11/labels{/name}","comments_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/11/comments","events_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/11/events","html_url":"https://github.com/octo-cli-testorg/test-create-issue/issues/11","id":377189344,"node_id":"MDU6SXNzdWUzNzcxODkzNDQ=","number":11,"title":"test
       this","user":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"labels":[{"id":1093660620,"node_id":"MDU6TGFiZWwxMDkzNjYwNjIw","url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/labels/label1","name":"label1","color":"ededed","default":false},{"id":1093660621,"node_id":"MDU6TGFiZWwxMDkzNjYwNjIx","url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/labels/label2","name":"label2","color":"ededed","default":false}],"state":"open","locked":false,"assignee":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"assignees":[{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false}],"milestone":{"url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/milestones/1","html_url":"https://github.com/octo-cli-testorg/test-create-issue/milestone/1","labels_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/milestones/1/labels","id":3744381,"node_id":"MDk6TWlsZXN0b25lMzc0NDM4MQ==","number":1,"title":"first","description":"first
-      milestone","creator":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/go-github-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/go-github-cli-testuser/orgs","repos_url":"https://api.github.com/users/go-github-cli-testuser/repos","events_url":"https://api.github.com/users/go-github-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/go-github-cli-testuser/received_events","type":"User","site_admin":false},"open_issues":6,"closed_issues":0,"state":"open","created_at":"2018-10-16T21:27:27Z","updated_at":"2018-10-29T21:14:22Z","due_on":"2036-01-01T08:00:00Z","closed_at":null},"comments":0,"created_at":"2018-10-29T21:14:22Z","updated_at":"2018-10-29T21:14:22Z","closed_at":null,"author_association":"MEMBER","body":"test
+      milestone","creator":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"open_issues":11,"closed_issues":0,"state":"open","created_at":"2018-10-16T21:27:27Z","updated_at":"2018-11-04T20:08:45Z","due_on":"2036-01-01T08:00:00Z","closed_at":null},"comments":0,"created_at":"2018-11-04T20:08:45Z","updated_at":"2018-11-04T20:08:46Z","closed_at":null,"author_association":"MEMBER","body":"test
       this body","closed_by":null}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
-      - ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
       Cache-Control:
       - private, max-age=60, s-maxage=60
       Content-Length:
-      - "6179"
+      - "5891"
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 29 Oct 2018 21:14:22 GMT
+      - Sun, 04 Nov 2018 20:08:46 GMT
       Etag:
-      - '"15a65873267960eb7b8d3ea3c81df92f"'
+      - '"68486c259f2108166beb9d881c67458c"'
       Location:
-      - https://api.github.com/repos/go-github-cli-testorg/test-create-issue/issues/6
+      - https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/11
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
@@ -56,16 +57,16 @@ interactions:
       X-Github-Media-Type:
       - github.v3; format=json
       X-Github-Request-Id:
-      - 87C9:7E8C:37C85:83E69:5BD7782D
+      - 918C:1A3F:16CCE42:2DCA72C:5BDF51CD
       X-Oauth-Scopes:
       - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
         delete_repo, gist, notifications, repo, user, write:discussion
       X-Ratelimit-Limit:
       - "5000"
       X-Ratelimit-Remaining:
-      - "4996"
+      - "4994"
       X-Ratelimit-Reset:
-      - "1540848229"
+      - "1541362786"
       X-Xss-Protection:
       - 1; mode=block
     status: 201 Created

--- a/tests/testdata/fixtures/test_issues_get.yaml
+++ b/tests/testdata/fixtures/test_issues_get.yaml
@@ -1,0 +1,69 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.github.v3+json
+    url: https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/1
+    method: GET
+  response:
+    body: '{"url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/1","repository_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue","labels_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/1/labels{/name}","comments_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/1/comments","events_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/issues/1/events","html_url":"https://github.com/octo-cli-testorg/test-create-issue/issues/1","id":370809832,"node_id":"MDU6SXNzdWUzNzA4MDk4MzI=","number":1,"title":"\"test
+      this\"","user":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"labels":[{"id":1093660620,"node_id":"MDU6TGFiZWwxMDkzNjYwNjIw","url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/labels/label1","name":"label1","color":"ededed","default":false},{"id":1093660621,"node_id":"MDU6TGFiZWwxMDkzNjYwNjIx","url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/labels/label2","name":"label2","color":"ededed","default":false}],"state":"open","locked":false,"assignee":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"assignees":[{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false}],"milestone":{"url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/milestones/1","html_url":"https://github.com/octo-cli-testorg/test-create-issue/milestone/1","labels_url":"https://api.github.com/repos/octo-cli-testorg/test-create-issue/milestones/1/labels","id":3744381,"node_id":"MDk6TWlsZXN0b25lMzc0NDM4MQ==","number":1,"title":"first","description":"first
+      milestone","creator":{"login":"octo-cli-testuser","id":44212809,"node_id":"MDQ6VXNlcjQ0MjEyODA5","avatar_url":"https://avatars0.githubusercontent.com/u/44212809?v=4","gravatar_id":"","url":"https://api.github.com/users/octo-cli-testuser","html_url":"https://github.com/octo-cli-testuser","followers_url":"https://api.github.com/users/octo-cli-testuser/followers","following_url":"https://api.github.com/users/octo-cli-testuser/following{/other_user}","gists_url":"https://api.github.com/users/octo-cli-testuser/gists{/gist_id}","starred_url":"https://api.github.com/users/octo-cli-testuser/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octo-cli-testuser/subscriptions","organizations_url":"https://api.github.com/users/octo-cli-testuser/orgs","repos_url":"https://api.github.com/users/octo-cli-testuser/repos","events_url":"https://api.github.com/users/octo-cli-testuser/events{/privacy}","received_events_url":"https://api.github.com/users/octo-cli-testuser/received_events","type":"User","site_admin":false},"open_issues":9,"closed_issues":0,"state":"open","created_at":"2018-10-16T21:27:27Z","updated_at":"2018-11-04T20:06:20Z","due_on":"2036-01-01T08:00:00Z","closed_at":null},"comments":0,"created_at":"2018-10-16T21:35:22Z","updated_at":"2018-10-16T21:35:22Z","closed_at":null,"author_association":"MEMBER","body":"\"test
+      this body\"","closed_by":null}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
+        X-GitHub-Media-Type
+      Cache-Control:
+      - private, max-age=60, s-maxage=60
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sun, 04 Nov 2018 20:06:21 GMT
+      Etag:
+      - W/"d1b94491f8f81748b42202e01f35eff5"
+      Last-Modified:
+      - Sun, 04 Nov 2018 20:06:20 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - GitHub.com
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept, Authorization, Cookie, X-GitHub-OTP
+      X-Accepted-Oauth-Scopes:
+      - repo
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Github-Media-Type:
+      - github.v3; format=json
+      X-Github-Request-Id:
+      - 9AC3:1A3E:1369A88:27B2A66:5BDF513C
+      X-Oauth-Scopes:
+      - admin:gpg_key, admin:org, admin:org_hook, admin:public_key, admin:repo_hook,
+        delete_repo, gist, notifications, repo, user, write:discussion
+      X-Ratelimit-Limit:
+      - "5000"
+      X-Ratelimit-Remaining:
+      - "4996"
+      X-Ratelimit-Reset:
+      - "1541362786"
+      X-Xss-Protection:
+      - 1; mode=block
+    status: 200 OK
+    code: 200
+    duration: ""

--- a/tests/testhelper_test.go
+++ b/tests/testhelper_test.go
@@ -5,7 +5,9 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
+	"github.com/octo-cli/octo-cli/generated"
 	"github.com/octo-cli/octo-cli/internal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"net/http"
@@ -18,18 +20,25 @@ func init() {
 	tkn, ok := os.LookupEnv("TESTUSER_TOKEN")
 	if !ok {
 		tkn = "deadbeef"
+		recorderMode = recorder.ModeReplaying
+	} else {
+		recorderMode = recorder.ModeRecording
 	}
 	_ = os.Setenv("GITHUB_TOKEN", tkn)
 }
 
+var recorderMode recorder.Mode
+
 func startVCR(t *testing.T, recPath string) func() {
 	t.Helper()
 	var err error
-	rec, err := recorder.New(recPath)
+	rec, err := recorder.NewAsMode(recPath, recorderMode, nil)
 	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
 		var b bytes.Buffer
-		if _, err := b.ReadFrom(r.Body); err != nil {
-			return false
+		if r.Body != nil {
+			if _, err := b.ReadFrom(r.Body); err != nil {
+				return false
+			}
 		}
 		r.Body = ioutil.NopCloser(&b)
 		return cassette.DefaultMatcher(r, i) &&
@@ -44,7 +53,25 @@ func startVCR(t *testing.T, recPath string) func() {
 	}
 }
 
-func testCmdLine(t *testing.T, fixtureName string, cmdStruct interface{}, cmdline ...string) (sout bytes.Buffer, serr bytes.Buffer, err error) {
+type cmdLine []string
+
+func newCmdLine(cmd string, args ...string) cmdLine {
+	return append(cmdLine{cmd}, args...)
+}
+
+func (c cmdLine) test(t *testing.T, fixtureName, wantStdout, wantStderr string, wantErr bool) {
+	t.Helper()
+	stdout, stderr, err := runCmdLine(t, fixtureName, &generated.CLI{}, c...)
+	if wantErr {
+		assert.Error(t, err)
+	} else {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, wantStdout, stdout.String())
+	assert.Equal(t, wantStderr, stderr.String())
+}
+
+func runCmdLine(t *testing.T, fixtureName string, cmdStruct interface{}, cmdline ...string) (sout bytes.Buffer, serr bytes.Buffer, err error) {
 	t.Helper()
 	recCleanup := startVCR(t, filepath.Join("testdata", "fixtures", fixtureName))
 	defer recCleanup()


### PR DESCRIPTION
Update vcr tests to re-record any time TESTUSER_TOKEN is present.  TESTUSER_TOKEN needs to be a PAT for octo-cli-testuser.  I'm having trouble figuring out how to make that scalable.  I don't want to give a token to everybody who might want to add or modify tests on this project.  We could add it as a secret in travis or a github action that records tests, but that seems like a cumbersome development cycle.