### PR TITLE
make update-testdata copy routes.json instead of downloading it

### DIFF
--- a/buildtool/generator/generator.go
+++ b/buildtool/generator/generator.go
@@ -103,6 +103,9 @@ func verify(routesPath, outputPath string) ([]string, error) {
 }
 
 func Generate(routesPath, outputPath string, fs afero.Fs) {
+	if fs == nil {
+		fs = afero.NewOsFs()
+	}
 	CLITmpl := StructTmplHelper{
 		Name: "CLI",
 	}

--- a/buildtool/generator/testdata/generated/issuescmd.go
+++ b/buildtool/generator/testdata/generated/issuescmd.go
@@ -692,7 +692,7 @@ type IssuesAddLabelsCmd struct {
 	Owner    string   `required:"" name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Number   int64    `required:"" name:"number"`
-	Labels   []string "required:\"\" name:\"labels\" help:\"The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.\""
+	Labels   []string `required:"" name:"labels"`
 }
 
 func (c *IssuesAddLabelsCmd) Run(isValueSetMap map[string]bool) error {
@@ -728,10 +728,11 @@ func (c *IssuesRemoveLabelCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesReplaceLabelsCmd struct {
 	internal.BaseCmd
-	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
-	Repo     string `required:"" name:"repo"`
-	Number   int64  `required:"" name:"number"`
+	Symmetra bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
+	Owner    string   `required:"" name:"owner"`
+	Repo     string   `required:"" name:"repo"`
+	Number   int64    `required:"" name:"number"`
+	Labels   []string `required:"" name:"labels"`
 }
 
 func (c *IssuesReplaceLabelsCmd) Run(isValueSetMap map[string]bool) error {
@@ -741,6 +742,7 @@ func (c *IssuesReplaceLabelsCmd) Run(isValueSetMap map[string]bool) error {
 	c.UpdateURLPath("owner", c.Owner)
 	c.UpdateURLPath("repo", c.Repo)
 	c.UpdateURLPath("number", c.Number)
+	c.UpdateBody("labels", c.Labels)
 	return c.DoRequest("PUT")
 }
 

--- a/buildtool/generator/testdata/routes.json
+++ b/buildtool/generator/testdata/routes.json
@@ -3531,8 +3531,8 @@
                 "title": "Spell Checker",
                 "message": "Check your spelling for 'banaas'.",
                 "raw_details": "Do you mean 'bananas' or 'banana'?",
-                "start_line": 2,
-                "end_line": 2
+                "start_line": "2",
+                "end_line": "2"
               },
               {
                 "path": "README.md",
@@ -3540,8 +3540,8 @@
                 "title": "Spell Checker",
                 "message": "Check your spelling for 'aples'",
                 "raw_details": "Do you mean 'apples' or 'Naples'",
-                "start_line": 4,
-                "end_line": 4
+                "start_line": "4",
+                "end_line": "4"
               }
             ],
             "images": [
@@ -3720,7 +3720,7 @@
           "location": "query"
         }
       ],
-      "description": "Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.",
+      "description": "Lists check runs for a commit ref. The `ref` can be a SHA, branch name, or a tag name. To list check runs, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.",
       "responses": [
         {
           "headers": {
@@ -3892,7 +3892,7 @@
           "location": "query"
         }
       ],
-      "description": "Lists check runs for a check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.",
+      "description": "Lists check runs for a check suite using its `id`. To list check runs, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.",
       "responses": [
         {
           "headers": {
@@ -4017,7 +4017,7 @@
           "location": "url"
         }
       ],
-      "description": "Gets a single check run using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check runs. OAuth Apps and authenticated users must have the `repo` scope to get check runs in a private repository.",
+      "description": "Gets a single check run using its `id`. To get a check run, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.",
       "responses": [
         {
           "headers": {
@@ -4153,7 +4153,7 @@
           "location": "query"
         }
       ],
-      "description": "Lists annotations for a check run using the annotation `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get annotations for a check run. OAuth Apps and authenticated users must have the `repo` scope to get annotations for a check run in a private repository.",
+      "description": "Lists annotations for a check run using the annotation `id`. To list annotations for a check run, your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository.",
       "responses": [
         {
           "headers": {
@@ -4213,7 +4213,7 @@
           "location": "url"
         }
       ],
-      "description": "Gets a single check suite using its `id`. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.",
+      "description": "Gets a single check suite using its `id`. Your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository to get check suites.",
       "responses": [
         {
           "headers": {
@@ -4436,7 +4436,7 @@
           "app_id": 1
         }
       ],
-      "description": "Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. GitHub Apps must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites. OAuth Apps and authenticated users must have the `repo` scope to get check suites in a private repository.",
+      "description": "Lists check suites for a commit `ref`. The `ref` can be a SHA, branch name, or a tag name. Your GitHub App must have the `checks:read` permission on a private repository or pull access to a public repository to list check suites.",
       "responses": [
         {
           "headers": {
@@ -8814,21 +8814,20 @@
           },
           "body": [
             {
-              "url": "https://api.github.com/marketplace_listing/plans/1313",
-              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-              "id": 1313,
-              "number": 3,
+              "url": "https://api.github.com/marketplace_listing/plans/9",
+              "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+              "id": 9,
               "name": "Pro",
               "description": "A professional-grade CI solution",
               "monthly_price_in_cents": 1099,
               "yearly_price_in_cents": 11870,
               "price_model": "flat-rate",
               "has_free_trial": true,
-              "unit_name": null,
               "state": "published",
+              "unit_name": null,
               "bullets": [
-                "Up to 25 private repositories",
-                "11 concurrent builds"
+                "This is the first bullet of the plan",
+                "This is the second bullet of the plan"
               ]
             }
           ]
@@ -8870,21 +8869,20 @@
           },
           "body": [
             {
-              "url": "https://api.github.com/marketplace_listing/plans/1313",
-              "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-              "id": 1313,
-              "number": 3,
+              "url": "https://api.github.com/marketplace_listing/plans/9",
+              "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+              "id": 9,
               "name": "Pro",
               "description": "A professional-grade CI solution",
               "monthly_price_in_cents": 1099,
               "yearly_price_in_cents": 11870,
               "price_model": "flat-rate",
               "has_free_trial": true,
-              "unit_name": null,
               "state": "published",
+              "unit_name": null,
               "bullets": [
-                "Up to 25 private repositories",
-                "11 concurrent builds"
+                "This is the first bullet of the plan",
+                "This is the second bullet of the plan"
               ]
             }
           ]
@@ -8947,7 +8945,7 @@
           "location": "query"
         }
       ],
-      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
       "responses": [
         {
           "headers": {
@@ -8962,29 +8960,6 @@
               "login": "github",
               "email": null,
               "organization_billing_email": "billing@github.com",
-              "marketplace_pending_change": {
-                "effective_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "id": 77,
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1111",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                  "id": 1111,
-                  "number": 2,
-                  "name": "Startup",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 699,
-                  "yearly_price_in_cents": 7870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "state": "published",
-                  "unit_name": null,
-                  "bullets": [
-                    "Up to 10 private repositories",
-                    "3 concurrent builds"
-                  ]
-                }
-              },
               "marketplace_purchase": {
                 "billing_cycle": "monthly",
                 "next_billing_date": "2017-11-11T00:00:00Z",
@@ -8993,21 +8968,20 @@
                 "free_trial_ends_on": "2017-11-11T00:00:00Z",
                 "updated_at": "2017-11-02T01:12:12Z",
                 "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1313",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                  "id": 1313,
-                  "number": 3,
+                  "url": "https://api.github.com/marketplace_listing/plans/9",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                  "id": 9,
                   "name": "Pro",
                   "description": "A professional-grade CI solution",
                   "monthly_price_in_cents": 1099,
                   "yearly_price_in_cents": 11870,
                   "price_model": "flat-rate",
                   "has_free_trial": true,
-                  "unit_name": null,
                   "state": "published",
+                  "unit_name": null,
                   "bullets": [
-                    "Up to 25 private repositories",
-                    "11 concurrent builds"
+                    "This is the first bullet of the plan",
+                    "This is the second bullet of the plan"
                   ]
                 }
               }
@@ -9072,7 +9046,7 @@
           "location": "query"
         }
       ],
-      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "description": "Returns any accounts associated with a plan, including free plans. For per-seat pricing, you see the list of accounts that have purchased the plan, including the number of seats purchased.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
       "responses": [
         {
           "headers": {
@@ -9087,29 +9061,6 @@
               "login": "github",
               "email": null,
               "organization_billing_email": "billing@github.com",
-              "marketplace_pending_change": {
-                "effective_date": "2017-11-11T00:00:00Z",
-                "unit_count": null,
-                "id": 77,
-                "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1111",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                  "id": 1111,
-                  "number": 2,
-                  "name": "Startup",
-                  "description": "A professional-grade CI solution",
-                  "monthly_price_in_cents": 699,
-                  "yearly_price_in_cents": 7870,
-                  "price_model": "flat-rate",
-                  "has_free_trial": true,
-                  "state": "published",
-                  "unit_name": null,
-                  "bullets": [
-                    "Up to 10 private repositories",
-                    "3 concurrent builds"
-                  ]
-                }
-              },
               "marketplace_purchase": {
                 "billing_cycle": "monthly",
                 "next_billing_date": "2017-11-11T00:00:00Z",
@@ -9118,21 +9069,20 @@
                 "free_trial_ends_on": "2017-11-11T00:00:00Z",
                 "updated_at": "2017-11-02T01:12:12Z",
                 "plan": {
-                  "url": "https://api.github.com/marketplace_listing/plans/1313",
-                  "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                  "id": 1313,
-                  "number": 3,
+                  "url": "https://api.github.com/marketplace_listing/plans/9",
+                  "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                  "id": 9,
                   "name": "Pro",
                   "description": "A professional-grade CI solution",
                   "monthly_price_in_cents": 1099,
                   "yearly_price_in_cents": 11870,
                   "price_model": "flat-rate",
                   "has_free_trial": true,
-                  "unit_name": null,
                   "state": "published",
+                  "unit_name": null,
                   "bullets": [
-                    "Up to 25 private repositories",
-                    "11 concurrent builds"
+                    "This is the first bullet of the plan",
+                    "This is the second bullet of the plan"
                   ]
                 }
               }
@@ -9174,7 +9124,7 @@
           "location": "query"
         }
       ],
-      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "description": "Checks whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
       "responses": [
         {
           "headers": {
@@ -9188,29 +9138,6 @@
             "login": "github",
             "email": null,
             "organization_billing_email": "billing@github.com",
-            "marketplace_pending_change": {
-              "effective_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "id": 77,
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1111",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                "id": 1111,
-                "number": 2,
-                "name": "Startup",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 699,
-                "yearly_price_in_cents": 7870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "state": "published",
-                "unit_name": null,
-                "bullets": [
-                  "Up to 10 private repositories",
-                  "3 concurrent builds"
-                ]
-              }
-            },
             "marketplace_purchase": {
               "billing_cycle": "monthly",
               "next_billing_date": "2017-11-11T00:00:00Z",
@@ -9219,21 +9146,20 @@
               "free_trial_ends_on": "2017-11-11T00:00:00Z",
               "updated_at": "2017-11-02T01:12:12Z",
               "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
+                "url": "https://api.github.com/marketplace_listing/plans/9",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                "id": 9,
                 "name": "Pro",
                 "description": "A professional-grade CI solution",
                 "monthly_price_in_cents": 1099,
                 "yearly_price_in_cents": 11870,
                 "price_model": "flat-rate",
                 "has_free_trial": true,
-                "unit_name": null,
                 "state": "published",
+                "unit_name": null,
                 "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
+                  "This is the first bullet of the plan",
+                  "This is the second bullet of the plan"
                 ]
               }
             }
@@ -9274,7 +9200,7 @@
           "location": "query"
         }
       ],
-      "description": "Shows whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App. When someone submits a plan change that won't be processed until the end of their billing cycle, you will also see the upcoming pending change.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
+      "description": "Checks whether the user or organization account actively subscribes to a plan listed by the authenticated GitHub App.\n\nGitHub Apps must use a [JWT](https://developer.github.com/apps/building-github-apps/authenticating-with-github-apps/#authenticating-as-a-github-app) to access this endpoint. OAuth Apps must use [basic authentication](https://developer.github.com/v3/auth/#basic-authentication) with their client ID and client secret to access this endpoint.",
       "responses": [
         {
           "headers": {
@@ -9288,29 +9214,6 @@
             "login": "github",
             "email": null,
             "organization_billing_email": "billing@github.com",
-            "marketplace_pending_change": {
-              "effective_date": "2017-11-11T00:00:00Z",
-              "unit_count": null,
-              "id": 77,
-              "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1111",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1111/accounts",
-                "id": 1111,
-                "number": 2,
-                "name": "Startup",
-                "description": "A professional-grade CI solution",
-                "monthly_price_in_cents": 699,
-                "yearly_price_in_cents": 7870,
-                "price_model": "flat-rate",
-                "has_free_trial": true,
-                "state": "published",
-                "unit_name": null,
-                "bullets": [
-                  "Up to 10 private repositories",
-                  "3 concurrent builds"
-                ]
-              }
-            },
             "marketplace_purchase": {
               "billing_cycle": "monthly",
               "next_billing_date": "2017-11-11T00:00:00Z",
@@ -9319,21 +9222,20 @@
               "free_trial_ends_on": "2017-11-11T00:00:00Z",
               "updated_at": "2017-11-02T01:12:12Z",
               "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
+                "url": "https://api.github.com/marketplace_listing/plans/9",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                "id": 9,
                 "name": "Pro",
                 "description": "A professional-grade CI solution",
                 "monthly_price_in_cents": 1099,
                 "yearly_price_in_cents": 11870,
                 "price_model": "flat-rate",
                 "has_free_trial": true,
-                "unit_name": null,
                 "state": "published",
+                "unit_name": null,
                 "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
+                  "This is the first bullet of the plan",
+                  "This is the second bullet of the plan"
                 ]
               }
             }
@@ -9391,21 +9293,20 @@
                 "type": "Organization"
               },
               "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
+                "url": "https://api.github.com/marketplace_listing/plans/9",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                "id": 9,
                 "name": "Pro",
                 "description": "A professional-grade CI solution",
                 "monthly_price_in_cents": 1099,
                 "yearly_price_in_cents": 11870,
                 "price_model": "flat-rate",
                 "has_free_trial": true,
-                "unit_name": null,
                 "state": "published",
+                "unit_name": null,
                 "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
+                  "This is the first bullet of the plan",
+                  "This is the second bullet of the plan"
                 ]
               }
             }
@@ -9463,21 +9364,20 @@
                 "type": "Organization"
               },
               "plan": {
-                "url": "https://api.github.com/marketplace_listing/plans/1313",
-                "accounts_url": "https://api.github.com/marketplace_listing/plans/1313/accounts",
-                "id": 1313,
-                "number": 3,
+                "url": "https://api.github.com/marketplace_listing/plans/9",
+                "accounts_url": "https://api.github.com/marketplace_listing/plans/9/accounts",
+                "id": 9,
                 "name": "Pro",
                 "description": "A professional-grade CI solution",
                 "monthly_price_in_cents": 1099,
                 "yearly_price_in_cents": 11870,
                 "price_model": "flat-rate",
                 "has_free_trial": true,
-                "unit_name": null,
                 "state": "published",
+                "unit_name": null,
                 "bullets": [
-                  "Up to 25 private repositories",
-                  "11 concurrent builds"
+                  "This is the first bullet of the plan",
+                  "This is the second bullet of the plan"
                 ]
               }
             }
@@ -9643,7 +9543,7 @@
                   "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                   "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                   "name": "bug",
-                  "description": "Something isn't working",
+                  "description": "Houston, we have a problem",
                   "color": "f29513",
                   "default": true
                 }
@@ -10005,7 +9905,7 @@
                   "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                   "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                   "name": "bug",
-                  "description": "Something isn't working",
+                  "description": "Houston, we have a problem",
                   "color": "f29513",
                   "default": true
                 }
@@ -10374,7 +10274,7 @@
                   "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                   "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                   "name": "bug",
-                  "description": "Something isn't working",
+                  "description": "Houston, we have a problem",
                   "color": "f29513",
                   "default": true
                 }
@@ -10763,7 +10663,7 @@
                   "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                   "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                   "name": "bug",
-                  "description": "Something isn't working",
+                  "description": "Houston, we have a problem",
                   "color": "f29513",
                   "default": true
                 }
@@ -10952,7 +10852,7 @@
                 "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                 "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                 "name": "bug",
-                "description": "Something isn't working",
+                "description": "Houston, we have a problem",
                 "color": "f29513",
                 "default": true
               }
@@ -11203,7 +11103,7 @@
                 "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                 "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                 "name": "bug",
-                "description": "Something isn't working",
+                "description": "Houston, we have a problem",
                 "color": "f29513",
                 "default": true
               }
@@ -11474,7 +11374,7 @@
                 "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                 "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                 "name": "bug",
-                "description": "Something isn't working",
+                "description": "Houston, we have a problem",
                 "color": "f29513",
                 "default": true
               }
@@ -11920,7 +11820,7 @@
                 "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                 "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                 "name": "bug",
-                "description": "Something isn't working",
+                "description": "Houston, we have a problem",
                 "color": "f29513",
                 "default": true
               }
@@ -12158,7 +12058,7 @@
                 "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                 "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                 "name": "bug",
-                "description": "Something isn't working",
+                "description": "Houston, we have a problem",
                 "color": "f29513",
                 "default": true
               }
@@ -12982,7 +12882,7 @@
                     "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                     "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                     "name": "bug",
-                    "description": "Something isn't working",
+                    "description": "Houston, we have a problem",
                     "color": "f29513",
                     "default": true
                   }
@@ -13205,7 +13105,7 @@
                   "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
                   "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
                   "name": "bug",
-                  "description": "Something isn't working",
+                  "description": "Houston, we have a problem",
                   "color": "f29513",
                   "default": true
                 }
@@ -13365,18 +13265,9 @@
               "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
               "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
               "name": "bug",
-              "description": "Something isn't working",
+              "description": "Houston, we have a problem",
               "color": "f29513",
               "default": true
-            },
-            {
-              "id": 208045947,
-              "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
-              "url": "https://api.github.com/repos/octocat/Hello-World/labels/enhancement",
-              "name": "enhancement",
-              "description": "New feature or request",
-              "color": "a2eeef",
-              "default": false
             }
           ]
         }
@@ -13431,7 +13322,7 @@
             "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
             "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
             "name": "bug",
-            "description": "Something isn't working",
+            "description": "Houston, we have a problem",
             "color": "f29513",
             "default": true
           }
@@ -13492,7 +13383,7 @@
       "requests": [
         {
           "name": "bug",
-          "description": "Something isn't working",
+          "description": "Houston, we have a problem",
           "color": "f29513"
         }
       ],
@@ -13508,7 +13399,7 @@
             "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
             "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
             "name": "bug",
-            "description": "Something isn't working",
+            "description": "Houston, we have a problem",
             "color": "f29513",
             "default": true
           }
@@ -13706,18 +13597,9 @@
               "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
               "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
               "name": "bug",
-              "description": "Something isn't working",
+              "description": "Houston, we have a problem",
               "color": "f29513",
               "default": true
-            },
-            {
-              "id": 208045947,
-              "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
-              "url": "https://api.github.com/repos/octocat/Hello-World/labels/enhancement",
-              "name": "enhancement",
-              "description": "New feature or request",
-              "color": "a2eeef",
-              "default": false
             }
           ]
         }
@@ -13760,20 +13642,19 @@
           "location": "url"
         },
         {
+          "mapTo": "input",
           "name": "labels",
           "type": "string[]",
-          "description": "The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.",
           "required": true,
+          "description": "",
           "location": "body"
         }
       ],
       "requests": [
-        {
-          "labels": [
-            "bug",
-            "enhancement"
-          ]
-        }
+        [
+          "Label1",
+          "Label2"
+        ]
       ],
       "description": "",
       "responses": [
@@ -13788,18 +13669,9 @@
               "node_id": "MDU6TGFiZWwyMDgwNDU5NDY=",
               "url": "https://api.github.com/repos/octocat/Hello-World/labels/bug",
               "name": "bug",
-              "description": "Something isn't working",
+              "description": "Houston, we have a problem",
               "color": "f29513",
               "default": true
-            },
-            {
-              "id": 208045947,
-              "node_id": "MDU6TGFiZWwyMDgwNDU5NDc=",
-              "url": "https://api.github.com/repos/octocat/Hello-World/labels/enhancement",
-              "name": "enhancement",
-              "description": "New feature or request",
-              "color": "a2eeef",
-              "default": false
             }
           ]
         }
@@ -13886,6 +13758,14 @@
           "required": true,
           "description": "",
           "location": "url"
+        },
+        {
+          "mapTo": "input",
+          "name": "labels",
+          "type": "string[]",
+          "required": true,
+          "description": "",
+          "location": "body"
         }
       ],
       "requests": [


### PR DESCRIPTION
downloading routes.json caused testdata to be ahead of production data in some cases.