### PR TITLE
Make setting owner and repo less verbose

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ Commands:
     List public events -
     https://developer.github.com/v3/activity/events/#list-public-events
 
-  activity list-repo-events --token=STRING --owner=STRING --repo=STRING
+  activity list-repo-events --token=STRING --repo=STRING
     List repository events -
     https://developer.github.com/v3/activity/events/#list-repository-events
 
-  activity list-public-events-for-repo-network --token=STRING --owner=STRING --repo=STRING
+  activity list-public-events-for-repo-network --token=STRING --repo=STRING
     List public events for a network of repositories -
     https://developer.github.com/v3/activity/events/#list-public-events-for-a-network-of-repositories
 
@@ -210,7 +210,7 @@ Commands:
     List your notifications -
     https://developer.github.com/v3/activity/notifications/#list-your-notifications
 
-  activity list-notifications-for-repo --token=STRING --owner=STRING --repo=STRING
+  activity list-notifications-for-repo --token=STRING --repo=STRING
     List your notifications in a repository -
     https://developer.github.com/v3/activity/notifications/#list-your-notifications-in-a-repository
 
@@ -218,7 +218,7 @@ Commands:
     Mark as read -
     https://developer.github.com/v3/activity/notifications/#mark-as-read
 
-  activity mark-notifications-as-read-for-repo --token=STRING --owner=STRING --repo=STRING
+  activity mark-notifications-as-read-for-repo --token=STRING --repo=STRING
     Mark notifications as read in a repository -
     https://developer.github.com/v3/activity/notifications/#mark-notifications-as-read-in-a-repository
 
@@ -242,7 +242,7 @@ Commands:
     Delete a thread subscription -
     https://developer.github.com/v3/activity/notifications/#delete-a-thread-subscription
 
-  activity list-stargazers-for-repo --token=STRING --owner=STRING --repo=STRING
+  activity list-stargazers-for-repo --token=STRING --repo=STRING
     List Stargazers -
     https://developer.github.com/v3/activity/starring/#list-stargazers
 
@@ -254,19 +254,19 @@ Commands:
     List repositories being starred by the authenticated user -
     https://developer.github.com/v3/activity/starring/#list-repositories-being-starred
 
-  activity check-starring-repo --token=STRING --owner=STRING --repo=STRING
+  activity check-starring-repo --token=STRING --repo=STRING
     Check if you are starring a repository -
     https://developer.github.com/v3/activity/starring/#check-if-you-are-starring-a-repository
 
-  activity star-repo --token=STRING --owner=STRING --repo=STRING
+  activity star-repo --token=STRING --repo=STRING
     Star a repository -
     https://developer.github.com/v3/activity/starring/#star-a-repository
 
-  activity unstar-repo --token=STRING --owner=STRING --repo=STRING
+  activity unstar-repo --token=STRING --repo=STRING
     Unstar a repository -
     https://developer.github.com/v3/activity/starring/#unstar-a-repository
 
-  activity list-watchers-for-repo --token=STRING --owner=STRING --repo=STRING
+  activity list-watchers-for-repo --token=STRING --repo=STRING
     List watchers -
     https://developer.github.com/v3/activity/watching/#list-watchers
 
@@ -278,27 +278,27 @@ Commands:
     List repositories being watched by the authenticated user -
     https://developer.github.com/v3/activity/watching/#list-repositories-being-watched
 
-  activity get-repo-subscription --token=STRING --owner=STRING --repo=STRING
+  activity get-repo-subscription --token=STRING --repo=STRING
     Get a Repository Subscription -
     https://developer.github.com/v3/activity/watching/#get-a-repository-subscription
 
-  activity set-repo-subscription --token=STRING --owner=STRING --repo=STRING
+  activity set-repo-subscription --token=STRING --repo=STRING
     Set a Repository Subscription -
     https://developer.github.com/v3/activity/watching/#set-a-repository-subscription
 
-  activity delete-repo-subscription --token=STRING --owner=STRING --repo=STRING
+  activity delete-repo-subscription --token=STRING --repo=STRING
     Delete a Repository Subscription -
     https://developer.github.com/v3/activity/watching/#delete-a-repository-subscription
 
-  activity check-watching-repo-legacy --token=STRING --owner=STRING --repo=STRING
+  activity check-watching-repo-legacy --token=STRING --repo=STRING
     Check if you are watching a repository (LEGACY) -
     https://developer.github.com/v3/activity/watching/#check-if-you-are-watching-a-repository-legacy
 
-  activity watch-repo-legacy --token=STRING --owner=STRING --repo=STRING
+  activity watch-repo-legacy --token=STRING --repo=STRING
     Watch a repository (LEGACY) -
     https://developer.github.com/v3/activity/watching/#watch-a-repository-legacy
 
-  activity stop-watching-repo-legacy --token=STRING --owner=STRING --repo=STRING
+  activity stop-watching-repo-legacy --token=STRING --repo=STRING
     Stop watching a repository (LEGACY) -
     https://developer.github.com/v3/activity/watching/#stop-watching-a-repository-legacy
 
@@ -330,7 +330,7 @@ Commands:
     Find organization installation -
     https://developer.github.com/v3/apps/#find-organization-installation
 
-  apps find-repo-installation --token=STRING --machine-man-preview --owner=STRING --repo=STRING
+  apps find-repo-installation --token=STRING --machine-man-preview --repo=STRING
     Find repository installation -
     https://developer.github.com/v3/apps/#find-repository-installation
 
@@ -392,35 +392,35 @@ Commands:
     Get a user's Marketplace purchases (stubbed) -
     https://developer.github.com/v3/apps/marketplace/#get-a-users-marketplace-purchases
 
-  checks list-for-ref --token=STRING --antiope-preview --owner=STRING --repo=STRING --ref=STRING
+  checks list-for-ref --token=STRING --antiope-preview --repo=STRING --ref=STRING
     List check runs for a specific ref -
     https://developer.github.com/v3/checks/runs/#list-check-runs-for-a-specific-ref
 
-  checks list-for-suite --token=STRING --antiope-preview --owner=STRING --repo=STRING --check_suite_id=INT-64
+  checks list-for-suite --token=STRING --antiope-preview --repo=STRING --check_suite_id=INT-64
     List check runs in a check suite -
     https://developer.github.com/v3/checks/runs/#list-check-runs-in-a-check-suite
 
-  checks get --token=STRING --antiope-preview --owner=STRING --repo=STRING --check_run_id=INT-64
+  checks get --token=STRING --antiope-preview --repo=STRING --check_run_id=INT-64
     Get a single check run -
     https://developer.github.com/v3/checks/runs/#get-a-single-check-run
 
-  checks list-annotations --token=STRING --antiope-preview --owner=STRING --repo=STRING --check_run_id=INT-64
+  checks list-annotations --token=STRING --antiope-preview --repo=STRING --check_run_id=INT-64
     List annotations for a check run -
     https://developer.github.com/v3/checks/runs/#list-annotations-for-a-check-run
 
-  checks get-suite --token=STRING --antiope-preview --owner=STRING --repo=STRING --check_suite_id=INT-64
+  checks get-suite --token=STRING --antiope-preview --repo=STRING --check_suite_id=INT-64
     Get a single check suite -
     https://developer.github.com/v3/checks/suites/#get-a-single-check-suite
 
-  checks list-suites-for-ref --token=STRING --antiope-preview --owner=STRING --repo=STRING --ref=STRING
+  checks list-suites-for-ref --token=STRING --antiope-preview --repo=STRING --ref=STRING
     List check suites for a specific ref -
     https://developer.github.com/v3/checks/suites/#list-check-suites-for-a-specific-ref
 
-  checks create-suite --token=STRING --antiope-preview --owner=STRING --repo=STRING --head_sha=STRING
+  checks create-suite --token=STRING --antiope-preview --repo=STRING --head_sha=STRING
     Create a check suite -
     https://developer.github.com/v3/checks/suites/#create-a-check-suite
 
-  checks rerequest-suite --token=STRING --antiope-preview --owner=STRING --repo=STRING --check_suite_id=INT-64
+  checks rerequest-suite --token=STRING --antiope-preview --repo=STRING --check_suite_id=INT-64
     Rerequest check suite -
     https://developer.github.com/v3/checks/suites/#rerequest-check-suite
 
@@ -432,7 +432,7 @@ Commands:
     Get an individual code of conduct -
     https://developer.github.com/v3/codes_of_conduct/#get-an-individual-code-of-conduct
 
-  codes-of-conduct get-for-repo --token=STRING --scarlet-witch-preview --owner=STRING --repo=STRING
+  codes-of-conduct get-for-repo --token=STRING --scarlet-witch-preview --repo=STRING
     Get the contents of a repository's code of conduct -
     https://developer.github.com/v3/codes_of_conduct/#get-the-contents-of-a-repositorys-code-of-conduct
 
@@ -505,38 +505,38 @@ Commands:
     Delete a comment -
     https://developer.github.com/v3/gists/comments/#delete-a-comment
 
-  git get-blob --token=STRING --owner=STRING --repo=STRING --file_sha=STRING
+  git get-blob --token=STRING --repo=STRING --file_sha=STRING
     Get a blob - https://developer.github.com/v3/git/blobs/#get-a-blob
 
-  git create-blob --token=STRING --owner=STRING --repo=STRING --content=STRING
+  git create-blob --token=STRING --repo=STRING --content=STRING
     Create a blob - https://developer.github.com/v3/git/blobs/#create-a-blob
 
-  git get-commit --token=STRING --owner=STRING --repo=STRING --commit_sha=STRING
+  git get-commit --token=STRING --repo=STRING --commit_sha=STRING
     Get a commit - https://developer.github.com/v3/git/commits/#get-a-commit
 
-  git get-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  git get-ref --token=STRING --repo=STRING --ref=STRING
     Get a reference - https://developer.github.com/v3/git/refs/#get-a-reference
 
-  git list-refs --token=STRING --owner=STRING --repo=STRING
+  git list-refs --token=STRING --repo=STRING
     Get all references -
     https://developer.github.com/v3/git/refs/#get-all-references
 
-  git create-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING --sha=STRING
+  git create-ref --token=STRING --repo=STRING --ref=STRING --sha=STRING
     Create a reference -
     https://developer.github.com/v3/git/refs/#create-a-reference
 
-  git update-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING --sha=STRING
+  git update-ref --token=STRING --repo=STRING --ref=STRING --sha=STRING
     Update a reference -
     https://developer.github.com/v3/git/refs/#update-a-reference
 
-  git delete-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  git delete-ref --token=STRING --repo=STRING --ref=STRING
     Delete a reference -
     https://developer.github.com/v3/git/refs/#delete-a-reference
 
-  git get-tag --token=STRING --owner=STRING --repo=STRING --tag_sha=STRING
+  git get-tag --token=STRING --repo=STRING --tag_sha=STRING
     Get a tag - https://developer.github.com/v3/git/tags/#get-a-tag
 
-  git get-tree --token=STRING --owner=STRING --repo=STRING --tree_sha=STRING
+  git get-tree --token=STRING --repo=STRING --tree_sha=STRING
     Get a tree - https://developer.github.com/v3/git/trees/#get-a-tree
 
   gitignore list-templates --token=STRING
@@ -561,143 +561,143 @@ Commands:
     List all issues for a given organization assigned to the authenticated user
     - https://developer.github.com/v3/issues/#list-issues
 
-  issues list-for-repo --token=STRING --owner=STRING --repo=STRING
+  issues list-for-repo --token=STRING --repo=STRING
     List issues for a repository -
     https://developer.github.com/v3/issues/#list-issues-for-a-repository
 
-  issues get --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues get --token=STRING --repo=STRING --number=INT-64
     Get a single issue -
     https://developer.github.com/v3/issues/#get-a-single-issue
 
-  issues create --token=STRING --owner=STRING --repo=STRING --title=STRING
+  issues create --token=STRING --repo=STRING --title=STRING
     Create an issue - https://developer.github.com/v3/issues/#create-an-issue
 
-  issues edit --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues edit --token=STRING --repo=STRING --number=INT-64
     Edit an issue - https://developer.github.com/v3/issues/#edit-an-issue
 
-  issues lock --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues lock --token=STRING --repo=STRING --number=INT-64
     Lock an issue - https://developer.github.com/v3/issues/#lock-an-issue
 
-  issues unlock --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues unlock --token=STRING --repo=STRING --number=INT-64
     Unlock an issue - https://developer.github.com/v3/issues/#unlock-an-issue
 
-  issues list-assignees --token=STRING --owner=STRING --repo=STRING
+  issues list-assignees --token=STRING --repo=STRING
     List assignees -
     https://developer.github.com/v3/issues/assignees/#list-assignees
 
-  issues check-assignee --token=STRING --owner=STRING --repo=STRING --assignee=STRING
+  issues check-assignee --token=STRING --repo=STRING --assignee=STRING
     Check assignee -
     https://developer.github.com/v3/issues/assignees/#check-assignee
 
-  issues add-assignees --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues add-assignees --token=STRING --repo=STRING --number=INT-64
     Add assignees to an issue -
     https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue
 
-  issues remove-assignees --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues remove-assignees --token=STRING --repo=STRING --number=INT-64
     Remove assignees from an issue -
     https://developer.github.com/v3/issues/assignees/#remove-assignees-from-an-issue
 
-  issues list-comments --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues list-comments --token=STRING --repo=STRING --number=INT-64
     List comments on an issue -
     https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue
 
-  issues list-comments-for-repo --token=STRING --owner=STRING --repo=STRING
+  issues list-comments-for-repo --token=STRING --repo=STRING
     List comments in a repository -
     https://developer.github.com/v3/issues/comments/#list-comments-in-a-repository
 
-  issues get-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  issues get-comment --token=STRING --repo=STRING --comment_id=INT-64
     Get a single comment -
     https://developer.github.com/v3/issues/comments/#get-a-single-comment
 
-  issues create-comment --token=STRING --owner=STRING --repo=STRING --number=INT-64 --body=STRING
+  issues create-comment --token=STRING --repo=STRING --number=INT-64 --body=STRING
     Create a comment -
     https://developer.github.com/v3/issues/comments/#create-a-comment
 
-  issues edit-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64 --body=STRING
+  issues edit-comment --token=STRING --repo=STRING --comment_id=INT-64 --body=STRING
     Edit a comment -
     https://developer.github.com/v3/issues/comments/#edit-a-comment
 
-  issues delete-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  issues delete-comment --token=STRING --repo=STRING --comment_id=INT-64
     Delete a comment -
     https://developer.github.com/v3/issues/comments/#delete-a-comment
 
-  issues list-events --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues list-events --token=STRING --repo=STRING --number=INT-64
     List events for an issue -
     https://developer.github.com/v3/issues/events/#list-events-for-an-issue
 
-  issues list-events-for-repo --token=STRING --owner=STRING --repo=STRING
+  issues list-events-for-repo --token=STRING --repo=STRING
     List events for a repository -
     https://developer.github.com/v3/issues/events/#list-events-for-a-repository
 
-  issues get-event --token=STRING --owner=STRING --repo=STRING --event_id=INT-64
+  issues get-event --token=STRING --repo=STRING --event_id=INT-64
     Get a single event -
     https://developer.github.com/v3/issues/events/#get-a-single-event
 
-  issues list-labels-for-repo --token=STRING --owner=STRING --repo=STRING
+  issues list-labels-for-repo --token=STRING --repo=STRING
     List all labels for this repository -
     https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
 
-  issues get-label --token=STRING --owner=STRING --repo=STRING --name=STRING
+  issues get-label --token=STRING --repo=STRING --name=STRING
     Get a single label -
     https://developer.github.com/v3/issues/labels/#get-a-single-label
 
-  issues create-label --token=STRING --owner=STRING --repo=STRING --name=STRING --color=STRING
+  issues create-label --token=STRING --repo=STRING --name=STRING --color=STRING
     Create a label -
     https://developer.github.com/v3/issues/labels/#create-a-label
 
-  issues update-label --token=STRING --owner=STRING --repo=STRING --current_name=STRING
+  issues update-label --token=STRING --repo=STRING --current_name=STRING
     Update a label -
     https://developer.github.com/v3/issues/labels/#update-a-label
 
-  issues delete-label --token=STRING --owner=STRING --repo=STRING --name=STRING
+  issues delete-label --token=STRING --repo=STRING --name=STRING
     Delete a label -
     https://developer.github.com/v3/issues/labels/#delete-a-label
 
-  issues list-labels-on-issue --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues list-labels-on-issue --token=STRING --repo=STRING --number=INT-64
     List labels on an issue -
     https://developer.github.com/v3/issues/labels/#list-labels-on-an-issue
 
-  issues add-labels --token=STRING --owner=STRING --repo=STRING --number=INT-64 --labels=LABELS,...
+  issues add-labels --token=STRING --repo=STRING --number=INT-64 --labels=LABELS,...
     Add labels to an issue -
     https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue
 
-  issues remove-label --token=STRING --owner=STRING --repo=STRING --number=INT-64 --name=STRING
+  issues remove-label --token=STRING --repo=STRING --number=INT-64 --name=STRING
     Remove a label from an issue -
     https://developer.github.com/v3/issues/labels/#remove-a-label-from-an-issue
 
-  issues replace-labels --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues replace-labels --token=STRING --repo=STRING --number=INT-64
     Replace all labels for an issue -
     https://developer.github.com/v3/issues/labels/#replace-all-labels-for-an-issue
 
-  issues remove-labels --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues remove-labels --token=STRING --repo=STRING --number=INT-64
     Remove all labels from an issue -
     https://developer.github.com/v3/issues/labels/#remove-all-labels-from-an-issue
 
-  issues list-labels-for-milestone --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues list-labels-for-milestone --token=STRING --repo=STRING --number=INT-64
     Get labels for every issue in a milestone -
     https://developer.github.com/v3/issues/labels/#get-labels-for-every-issue-in-a-milestone
 
-  issues list-milestones-for-repo --token=STRING --owner=STRING --repo=STRING
+  issues list-milestones-for-repo --token=STRING --repo=STRING
     List milestones for a repository -
     https://developer.github.com/v3/issues/milestones/#list-milestones-for-a-repository
 
-  issues get-milestone --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues get-milestone --token=STRING --repo=STRING --number=INT-64
     Get a single milestone -
     https://developer.github.com/v3/issues/milestones/#get-a-single-milestone
 
-  issues create-milestone --token=STRING --owner=STRING --repo=STRING --title=STRING
+  issues create-milestone --token=STRING --repo=STRING --title=STRING
     Create a milestone -
     https://developer.github.com/v3/issues/milestones/#create-a-milestone
 
-  issues update-milestone --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues update-milestone --token=STRING --repo=STRING --number=INT-64
     Update a milestone -
     https://developer.github.com/v3/issues/milestones/#update-a-milestone
 
-  issues delete-milestone --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  issues delete-milestone --token=STRING --repo=STRING --number=INT-64
     Delete a milestone -
     https://developer.github.com/v3/issues/milestones/#delete-a-milestone
 
-  issues list-events-for-timeline --token=STRING --mockingbird-preview --owner=STRING --repo=STRING --number=INT-64
+  issues list-events-for-timeline --token=STRING --mockingbird-preview --repo=STRING --number=INT-64
     List events for an issue -
     https://developer.github.com/v3/issues/timeline/#list-events-for-an-issue
 
@@ -709,7 +709,7 @@ Commands:
     Get an individual license -
     https://developer.github.com/v3/licenses/#get-an-individual-license
 
-  licenses get-for-repo --token=STRING --owner=STRING --repo=STRING
+  licenses get-for-repo --token=STRING --repo=STRING
     Get the contents of a repository's license -
     https://developer.github.com/v3/licenses/#get-the-contents-of-a-repositorys-license
 
@@ -748,35 +748,35 @@ Commands:
     Unlock an organization repository -
     https://developer.github.com/v3/migrations/orgs/#unlock-an-organization-repository
 
-  migrations start-import --token=STRING --barred-rock-preview --owner=STRING --repo=STRING --vcs_url=STRING
+  migrations start-import --token=STRING --barred-rock-preview --repo=STRING --vcs_url=STRING
     Start an import -
     https://developer.github.com/v3/migrations/source_imports/#start-an-import
 
-  migrations get-import-progress --token=STRING --barred-rock-preview --owner=STRING --repo=STRING
+  migrations get-import-progress --token=STRING --barred-rock-preview --repo=STRING
     Get import progress -
     https://developer.github.com/v3/migrations/source_imports/#get-import-progress
 
-  migrations update-import --token=STRING --barred-rock-preview --owner=STRING --repo=STRING
+  migrations update-import --token=STRING --barred-rock-preview --repo=STRING
     Update existing import -
     https://developer.github.com/v3/migrations/source_imports/#update-existing-import
 
-  migrations get-commit-authors --token=STRING --barred-rock-preview --owner=STRING --repo=STRING
+  migrations get-commit-authors --token=STRING --barred-rock-preview --repo=STRING
     Get commit authors -
     https://developer.github.com/v3/migrations/source_imports/#get-commit-authors
 
-  migrations map-commit-author --token=STRING --barred-rock-preview --owner=STRING --repo=STRING --author_id=INT-64
+  migrations map-commit-author --token=STRING --barred-rock-preview --repo=STRING --author_id=INT-64
     Map a commit author -
     https://developer.github.com/v3/migrations/source_imports/#map-a-commit-author
 
-  migrations set-lfs-preference --token=STRING --barred-rock-preview --owner=STRING --repo=STRING --use_lfs=STRING
+  migrations set-lfs-preference --token=STRING --barred-rock-preview --repo=STRING --use_lfs=STRING
     Set Git LFS preference -
     https://developer.github.com/v3/migrations/source_imports/#set-git-lfs-preference
 
-  migrations get-large-files --token=STRING --barred-rock-preview --owner=STRING --repo=STRING
+  migrations get-large-files --token=STRING --barred-rock-preview --repo=STRING
     Get large files -
     https://developer.github.com/v3/migrations/source_imports/#get-large-files
 
-  migrations cancel-import --token=STRING --barred-rock-preview --owner=STRING --repo=STRING
+  migrations cancel-import --token=STRING --barred-rock-preview --repo=STRING
     Cancel an import -
     https://developer.github.com/v3/migrations/source_imports/#cancel-an-import
 
@@ -983,7 +983,7 @@ Commands:
   orgs delete-hook --token=STRING --org=STRING --hook_id=INT-64
     Delete a hook - https://developer.github.com/v3/orgs/hooks/#delete-a-hook
 
-  projects list-for-repo --token=STRING --inertia-preview --owner=STRING --repo=STRING
+  projects list-for-repo --token=STRING --inertia-preview --repo=STRING
     List repository projects -
     https://developer.github.com/v3/projects/#list-repository-projects
 
@@ -994,7 +994,7 @@ Commands:
   projects get --token=STRING --inertia-preview --project_id=INT-64
     Get a project - https://developer.github.com/v3/projects/#get-a-project
 
-  projects create-for-repo --token=STRING --inertia-preview --owner=STRING --repo=STRING --name=STRING
+  projects create-for-repo --token=STRING --inertia-preview --repo=STRING --name=STRING
     Create a repository project -
     https://developer.github.com/v3/projects/#create-a-repository-project
 
@@ -1074,103 +1074,103 @@ Commands:
     Move a project column -
     https://developer.github.com/v3/projects/columns/#move-a-project-column
 
-  pulls list --token=STRING --owner=STRING --repo=STRING
+  pulls list --token=STRING --repo=STRING
     List pull requests -
     https://developer.github.com/v3/pulls/#list-pull-requests
 
-  pulls get --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls get --token=STRING --repo=STRING --number=INT-64
     Get a single pull request -
     https://developer.github.com/v3/pulls/#get-a-single-pull-request
 
-  pulls create --token=STRING --owner=STRING --repo=STRING --title=STRING --head=STRING --base=STRING
+  pulls create --token=STRING --repo=STRING --title=STRING --head=STRING --base=STRING
     Create a pull request -
     https://developer.github.com/v3/pulls/#create-a-pull-request
 
-  pulls create-from-issue --token=STRING --owner=STRING --repo=STRING --issue=INT-64 --head=STRING --base=STRING
+  pulls create-from-issue --token=STRING --repo=STRING --issue=INT-64 --head=STRING --base=STRING
     Create a Pull Request from an Issue -
     https://developer.github.com/v3/pulls/#create-a-pull-request
 
-  pulls update --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls update --token=STRING --repo=STRING --number=INT-64
     Update a pull request -
     https://developer.github.com/v3/pulls/#update-a-pull-request
 
-  pulls list-commits --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls list-commits --token=STRING --repo=STRING --number=INT-64
     List commits on a pull request -
     https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
 
-  pulls list-files --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls list-files --token=STRING --repo=STRING --number=INT-64
     List pull requests files -
     https://developer.github.com/v3/pulls/#list-pull-requests-files
 
-  pulls check-if-merged --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls check-if-merged --token=STRING --repo=STRING --number=INT-64
     Get if a pull request has been merged -
     https://developer.github.com/v3/pulls/#get-if-a-pull-request-has-been-merged
 
-  pulls merge --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls merge --token=STRING --repo=STRING --number=INT-64
     Merge a pull request (Merge Button) -
     https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button
 
-  pulls list-reviews --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls list-reviews --token=STRING --repo=STRING --number=INT-64
     List reviews on a pull request -
     https://developer.github.com/v3/pulls/reviews/#list-reviews-on-a-pull-request
 
-  pulls get-review --token=STRING --owner=STRING --repo=STRING --number=INT-64 --review_id=INT-64
+  pulls get-review --token=STRING --repo=STRING --number=INT-64 --review_id=INT-64
     Get a single review -
     https://developer.github.com/v3/pulls/reviews/#get-a-single-review
 
-  pulls delete-pending-review --token=STRING --owner=STRING --repo=STRING --number=INT-64 --review_id=INT-64
+  pulls delete-pending-review --token=STRING --repo=STRING --number=INT-64 --review_id=INT-64
     Delete a pending review -
     https://developer.github.com/v3/pulls/reviews/#delete-a-pending-review
 
-  pulls get-comments-for-review --token=STRING --owner=STRING --repo=STRING --number=INT-64 --review_id=INT-64
+  pulls get-comments-for-review --token=STRING --repo=STRING --number=INT-64 --review_id=INT-64
     Get comments for a single review -
     https://developer.github.com/v3/pulls/reviews/#get-comments-for-a-single-review
 
-  pulls submit-review --token=STRING --owner=STRING --repo=STRING --number=INT-64 --review_id=INT-64 --event=STRING
+  pulls submit-review --token=STRING --repo=STRING --number=INT-64 --review_id=INT-64 --event=STRING
     Submit a pull request review -
     https://developer.github.com/v3/pulls/reviews/#submit-a-pull-request-review
 
-  pulls dismiss-review --token=STRING --owner=STRING --repo=STRING --number=INT-64 --review_id=INT-64 --message=STRING
+  pulls dismiss-review --token=STRING --repo=STRING --number=INT-64 --review_id=INT-64 --message=STRING
     Dismiss a pull request review -
     https://developer.github.com/v3/pulls/reviews/#dismiss-a-pull-request-review
 
-  pulls list-comments --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls list-comments --token=STRING --repo=STRING --number=INT-64
     List comments on a pull request -
     https://developer.github.com/v3/pulls/comments/#list-comments-on-a-pull-request
 
-  pulls list-comments-for-repo --token=STRING --owner=STRING --repo=STRING
+  pulls list-comments-for-repo --token=STRING --repo=STRING
     List comments in a repository -
     https://developer.github.com/v3/pulls/comments/#list-comments-in-a-repository
 
-  pulls get-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  pulls get-comment --token=STRING --repo=STRING --comment_id=INT-64
     Get a single comment -
     https://developer.github.com/v3/pulls/comments/#get-a-single-comment
 
-  pulls create-comment --token=STRING --owner=STRING --repo=STRING --number=INT-64 --body=STRING --commit_id=STRING --path=STRING --position=INT-64
+  pulls create-comment --token=STRING --repo=STRING --number=INT-64 --body=STRING --commit_id=STRING --path=STRING --position=INT-64
     Create a comment -
     https://developer.github.com/v3/pulls/comments/#create-a-comment
 
-  pulls create-comment-reply --token=STRING --owner=STRING --repo=STRING --number=INT-64 --body=STRING --in_reply_to=INT-64
+  pulls create-comment-reply --token=STRING --repo=STRING --number=INT-64 --body=STRING --in_reply_to=INT-64
     Create a comment reply -
     https://developer.github.com/v3/pulls/comments/#create-a-comment
 
-  pulls edit-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64 --body=STRING
+  pulls edit-comment --token=STRING --repo=STRING --comment_id=INT-64 --body=STRING
     Edit a comment -
     https://developer.github.com/v3/pulls/comments/#edit-a-comment
 
-  pulls delete-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  pulls delete-comment --token=STRING --repo=STRING --comment_id=INT-64
     Delete a comment -
     https://developer.github.com/v3/pulls/comments/#delete-a-comment
 
-  pulls list-review-requests --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls list-review-requests --token=STRING --repo=STRING --number=INT-64
     List review requests -
     https://developer.github.com/v3/pulls/review_requests/#list-review-requests
 
-  pulls create-review-request --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls create-review-request --token=STRING --repo=STRING --number=INT-64
     Create a review request -
     https://developer.github.com/v3/pulls/review_requests/#create-a-review-request
 
-  pulls delete-review-request --token=STRING --owner=STRING --repo=STRING --number=INT-64
+  pulls delete-review-request --token=STRING --repo=STRING --number=INT-64
     Delete a review request -
     https://developer.github.com/v3/pulls/review_requests/#delete-a-review-request
 
@@ -1178,35 +1178,35 @@ Commands:
     Get your current rate limit status -
     https://developer.github.com/v3/rate_limit/#get-your-current-rate-limit-status
 
-  reactions list-for-commit-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64
+  reactions list-for-commit-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64
     List reactions for a commit comment -
     https://developer.github.com/v3/reactions/#list-reactions-for-a-commit-comment
 
-  reactions create-for-commit-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64 --content=STRING
+  reactions create-for-commit-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64 --content=STRING
     Create reaction for a commit comment -
     https://developer.github.com/v3/reactions/#create-reaction-for-a-commit-comment
 
-  reactions list-for-issue --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --number=INT-64
+  reactions list-for-issue --token=STRING --squirrel-girl-preview --repo=STRING --number=INT-64
     List reactions for an issue -
     https://developer.github.com/v3/reactions/#list-reactions-for-an-issue
 
-  reactions create-for-issue --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --number=INT-64 --content=STRING
+  reactions create-for-issue --token=STRING --squirrel-girl-preview --repo=STRING --number=INT-64 --content=STRING
     Create reaction for an issue -
     https://developer.github.com/v3/reactions/#create-reaction-for-an-issue
 
-  reactions list-for-issue-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64
+  reactions list-for-issue-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64
     List reactions for an issue comment -
     https://developer.github.com/v3/reactions/#list-reactions-for-an-issue-comment
 
-  reactions create-for-issue-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64 --content=STRING
+  reactions create-for-issue-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64 --content=STRING
     Create reaction for an issue comment -
     https://developer.github.com/v3/reactions/#create-reaction-for-an-issue-comment
 
-  reactions list-for-pull-request-review-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64
+  reactions list-for-pull-request-review-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64
     List reactions for a pull request review comment -
     https://developer.github.com/v3/reactions/#list-reactions-for-a-pull-request-review-comment
 
-  reactions create-for-pull-request-review-comment --token=STRING --squirrel-girl-preview --owner=STRING --repo=STRING --comment_id=INT-64 --content=STRING
+  reactions create-for-pull-request-review-comment --token=STRING --squirrel-girl-preview --repo=STRING --comment_id=INT-64 --content=STRING
     Create reaction for a pull request review comment -
     https://developer.github.com/v3/reactions/#create-reaction-for-a-pull-request-review-comment
 
@@ -1254,297 +1254,297 @@ Commands:
     Create a new repository in this organization -
     https://developer.github.com/v3/repos/#create
 
-  repos get --token=STRING --owner=STRING --repo=STRING
+  repos get --token=STRING --repo=STRING
     Get - https://developer.github.com/v3/repos/#get
 
-  repos edit --token=STRING --owner=STRING --repo=STRING --name=STRING
+  repos edit --token=STRING --repo=STRING --name=STRING
     Edit - https://developer.github.com/v3/repos/#edit
 
-  repos list-topics --token=STRING --owner=STRING --repo=STRING
+  repos list-topics --token=STRING --repo=STRING
     List all topics for a repository -
     https://developer.github.com/v3/repos/#list-all-topics-for-a-repository
 
-  repos replace-topics --token=STRING --owner=STRING --repo=STRING --names=NAMES,...
+  repos replace-topics --token=STRING --repo=STRING --names=NAMES,...
     Replace all topics for a repository -
     https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
 
-  repos list-contributors --token=STRING --owner=STRING --repo=STRING
+  repos list-contributors --token=STRING --repo=STRING
     List contributors - https://developer.github.com/v3/repos/#list-contributors
 
-  repos list-languages --token=STRING --owner=STRING --repo=STRING
+  repos list-languages --token=STRING --repo=STRING
     List languages - https://developer.github.com/v3/repos/#list-languages
 
-  repos list-teams --token=STRING --owner=STRING --repo=STRING
+  repos list-teams --token=STRING --repo=STRING
     List teams - https://developer.github.com/v3/repos/#list-teams
 
-  repos list-tags --token=STRING --owner=STRING --repo=STRING
+  repos list-tags --token=STRING --repo=STRING
     List tags - https://developer.github.com/v3/repos/#list-tags
 
-  repos delete --token=STRING --owner=STRING --repo=STRING
+  repos delete --token=STRING --repo=STRING
     Delete a repository -
     https://developer.github.com/v3/repos/#delete-a-repository
 
-  repos transfer --token=STRING --nightshade-preview --owner=STRING --repo=STRING
+  repos transfer --token=STRING --nightshade-preview --repo=STRING
     Transfer a repository -
     https://developer.github.com/v3/repos/#transfer-a-repository
 
-  repos list-branches --token=STRING --owner=STRING --repo=STRING
+  repos list-branches --token=STRING --repo=STRING
     List branches -
     https://developer.github.com/v3/repos/branches/#list-branches
 
-  repos get-branch --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-branch --token=STRING --repo=STRING --branch=STRING
     Get branch - https://developer.github.com/v3/repos/branches/#get-branch
 
-  repos get-branch-protection --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-branch-protection --token=STRING --repo=STRING --branch=STRING
     Get branch protection -
     https://developer.github.com/v3/repos/branches/#get-branch-protection
 
-  repos remove-branch-protection --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos remove-branch-protection --token=STRING --repo=STRING --branch=STRING
     Remove branch protection -
     https://developer.github.com/v3/repos/branches/#remove-branch-protection
 
-  repos get-protected-branch-required-status-checks --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-protected-branch-required-status-checks --token=STRING --repo=STRING --branch=STRING
     Get required status checks of protected branch -
     https://developer.github.com/v3/repos/branches/#get-required-status-checks-of-protected-branch
 
-  repos update-protected-branch-required-status-checks --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos update-protected-branch-required-status-checks --token=STRING --repo=STRING --branch=STRING
     Update required status checks of protected branch -
     https://developer.github.com/v3/repos/branches/#update-required-status-checks-of-protected-branch
 
-  repos remove-protected-branch-required-status-checks --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos remove-protected-branch-required-status-checks --token=STRING --repo=STRING --branch=STRING
     Remove required status checks of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-required-status-checks-of-protected-branch
 
-  repos list-protected-branch-required-status-checks-contexts --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos list-protected-branch-required-status-checks-contexts --token=STRING --repo=STRING --branch=STRING
     List required status checks contexts of protected branch -
     https://developer.github.com/v3/repos/branches/#list-required-status-checks-contexts-of-protected-branch
 
-  repos replace-protected-branch-required-status-checks-contexts --token=STRING --owner=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
+  repos replace-protected-branch-required-status-checks-contexts --token=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
     Replace required status checks contexts of protected branch -
     https://developer.github.com/v3/repos/branches/#replace-required-status-checks-contexts-of-protected-branch
 
-  repos add-protected-branch-required-status-checks-contexts --token=STRING --owner=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
+  repos add-protected-branch-required-status-checks-contexts --token=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
     Add required status checks contexts of protected branch -
     https://developer.github.com/v3/repos/branches/#add-required-status-checks-contexts-of-protected-branch
 
-  repos remove-protected-branch-required-status-checks-contexts --token=STRING --owner=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
+  repos remove-protected-branch-required-status-checks-contexts --token=STRING --repo=STRING --branch=STRING --contexts=CONTEXTS,...
     Remove required status checks contexts of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-required-status-checks-contexts-of-protected-branch
 
-  repos get-protected-branch-pull-request-review-enforcement --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-protected-branch-pull-request-review-enforcement --token=STRING --repo=STRING --branch=STRING
     Get pull request review enforcement of protected branch -
     https://developer.github.com/v3/repos/branches/#get-pull-request-review-enforcement-of-protected-branch
 
-  repos remove-protected-branch-pull-request-review-enforcement --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos remove-protected-branch-pull-request-review-enforcement --token=STRING --repo=STRING --branch=STRING
     Remove pull request review enforcement of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-pull-request-review-enforcement-of-protected-branch
 
-  repos get-protected-branch-required-signatures --token=STRING --zzzax-preview --owner=STRING --repo=STRING --branch=STRING
+  repos get-protected-branch-required-signatures --token=STRING --zzzax-preview --repo=STRING --branch=STRING
     Get required signatures of protected branch -
     https://developer.github.com/v3/repos/branches/#get-required-signatures-of-protected-branch
 
-  repos add-protected-branch-required-signatures --token=STRING --zzzax-preview --owner=STRING --repo=STRING --branch=STRING
+  repos add-protected-branch-required-signatures --token=STRING --zzzax-preview --repo=STRING --branch=STRING
     Add required signatures of protected branch -
     https://developer.github.com/v3/repos/branches/#add-required-signatures-of-protected-branch
 
-  repos remove-protected-branch-required-signatures --token=STRING --zzzax-preview --owner=STRING --repo=STRING --branch=STRING
+  repos remove-protected-branch-required-signatures --token=STRING --zzzax-preview --repo=STRING --branch=STRING
     Remove required signatures of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-required-signatures-of-protected-branch
 
-  repos get-protected-branch-admin-enforcement --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-protected-branch-admin-enforcement --token=STRING --repo=STRING --branch=STRING
     Get admin enforcement of protected branch -
     https://developer.github.com/v3/repos/branches/#get-admin-enforcement-of-protected-branch
 
-  repos add-protected-branch-admin-enforcement --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos add-protected-branch-admin-enforcement --token=STRING --repo=STRING --branch=STRING
     Add admin enforcement of protected branch -
     https://developer.github.com/v3/repos/branches/#add-admin-enforcement-of-protected-branch
 
-  repos remove-protected-branch-admin-enforcement --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos remove-protected-branch-admin-enforcement --token=STRING --repo=STRING --branch=STRING
     Remove admin enforcement of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-admin-enforcement-of-protected-branch
 
-  repos get-protected-branch-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos get-protected-branch-restrictions --token=STRING --repo=STRING --branch=STRING
     Get restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#get-restrictions-of-protected-branch
 
-  repos remove-protected-branch-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos remove-protected-branch-restrictions --token=STRING --repo=STRING --branch=STRING
     Remove restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-restrictions-of-protected-branch
 
-  repos list-protected-branch-team-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos list-protected-branch-team-restrictions --token=STRING --repo=STRING --branch=STRING
     List team restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#list-team-restrictions-of-protected-branch
 
-  repos replace-protected-branch-team-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
+  repos replace-protected-branch-team-restrictions --token=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
     Replace team restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#replace-team-restrictions-of-protected-branch
 
-  repos add-protected-branch-team-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
+  repos add-protected-branch-team-restrictions --token=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
     Add team restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#add-team-restrictions-of-protected-branch
 
-  repos remove-protected-branch-team-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
+  repos remove-protected-branch-team-restrictions --token=STRING --repo=STRING --branch=STRING --teams=TEAMS,...
     Remove team restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-team-restrictions-of-protected-branch
 
-  repos list-protected-branch-user-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING
+  repos list-protected-branch-user-restrictions --token=STRING --repo=STRING --branch=STRING
     List user restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#list-user-restrictions-of-protected-branch
 
-  repos replace-protected-branch-user-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --users=USERS,...
+  repos replace-protected-branch-user-restrictions --token=STRING --repo=STRING --branch=STRING --users=USERS,...
     Replace user restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#replace-user-restrictions-of-protected-branch
 
-  repos add-protected-branch-user-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --users=USERS,...
+  repos add-protected-branch-user-restrictions --token=STRING --repo=STRING --branch=STRING --users=USERS,...
     Add user restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#add-user-restrictions-of-protected-branch
 
-  repos remove-protected-branch-user-restrictions --token=STRING --owner=STRING --repo=STRING --branch=STRING --users=USERS,...
+  repos remove-protected-branch-user-restrictions --token=STRING --repo=STRING --branch=STRING --users=USERS,...
     Remove user restrictions of protected branch -
     https://developer.github.com/v3/repos/branches/#remove-user-restrictions-of-protected-branch
 
-  repos list-collaborators --token=STRING --owner=STRING --repo=STRING
+  repos list-collaborators --token=STRING --repo=STRING
     List collaborators -
     https://developer.github.com/v3/repos/collaborators/#list-collaborators
 
-  repos check-collaborator --token=STRING --owner=STRING --repo=STRING --username=STRING
+  repos check-collaborator --token=STRING --repo=STRING --username=STRING
     Check if a user is a collaborator -
     https://developer.github.com/v3/repos/collaborators/#check-if-a-user-is-a-collaborator
 
-  repos get-collaborator-permission-level --token=STRING --owner=STRING --repo=STRING --username=STRING
+  repos get-collaborator-permission-level --token=STRING --repo=STRING --username=STRING
     Review a user's permission level -
     https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
 
-  repos add-collaborator --token=STRING --owner=STRING --repo=STRING --username=STRING
+  repos add-collaborator --token=STRING --repo=STRING --username=STRING
     Add user as a collaborator -
     https://developer.github.com/v3/repos/collaborators/#add-user-as-a-collaborator
 
-  repos remove-collaborator --token=STRING --owner=STRING --repo=STRING --username=STRING
+  repos remove-collaborator --token=STRING --repo=STRING --username=STRING
     Remove user as a collaborator -
     https://developer.github.com/v3/repos/collaborators/#remove-user-as-a-collaborator
 
-  repos list-commit-comments --token=STRING --owner=STRING --repo=STRING
+  repos list-commit-comments --token=STRING --repo=STRING
     List commit comments for a repository -
     https://developer.github.com/v3/repos/comments/#list-commit-comments-for-a-repository
 
-  repos list-comments-for-commit --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  repos list-comments-for-commit --token=STRING --repo=STRING --ref=STRING
     List comments for a single commit -
     https://developer.github.com/v3/repos/comments/#list-comments-for-a-single-commit
 
-  repos create-commit-comment --token=STRING --owner=STRING --repo=STRING --sha=STRING --body=STRING
+  repos create-commit-comment --token=STRING --repo=STRING --sha=STRING --body=STRING
     Create a commit comment -
     https://developer.github.com/v3/repos/comments/#create-a-commit-comment
 
-  repos get-commit-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  repos get-commit-comment --token=STRING --repo=STRING --comment_id=INT-64
     Get a single commit comment -
     https://developer.github.com/v3/repos/comments/#get-a-single-commit-comment
 
-  repos update-commit-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64 --body=STRING
+  repos update-commit-comment --token=STRING --repo=STRING --comment_id=INT-64 --body=STRING
     Update a commit comment -
     https://developer.github.com/v3/repos/comments/#update-a-commit-comment
 
-  repos delete-commit-comment --token=STRING --owner=STRING --repo=STRING --comment_id=INT-64
+  repos delete-commit-comment --token=STRING --repo=STRING --comment_id=INT-64
     Delete a commit comment -
     https://developer.github.com/v3/repos/comments/#delete-a-commit-comment
 
-  repos list-commits --token=STRING --owner=STRING --repo=STRING
+  repos list-commits --token=STRING --repo=STRING
     List commits on a repository -
     https://developer.github.com/v3/repos/commits/#list-commits-on-a-repository
 
-  repos get-commit --token=STRING --owner=STRING --repo=STRING --sha=STRING
+  repos get-commit --token=STRING --repo=STRING --sha=STRING
     Get a single commit -
     https://developer.github.com/v3/repos/commits/#get-a-single-commit
 
-  repos get-commit-ref-sha --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  repos get-commit-ref-sha --token=STRING --repo=STRING --ref=STRING
     Get the SHA-1 of a commit reference -
     https://developer.github.com/v3/repos/commits/#get-the-sha-1-of-a-commit-reference
 
-  repos compare-commits --token=STRING --owner=STRING --repo=STRING --base=STRING --head=STRING
+  repos compare-commits --token=STRING --repo=STRING --base=STRING --head=STRING
     Compare two commits -
     https://developer.github.com/v3/repos/commits/#compare-two-commits
 
-  repos retrieve-community-profile-metrics --token=STRING --owner=STRING --repo=STRING
+  repos retrieve-community-profile-metrics --token=STRING --repo=STRING
     Retrieve community profile metrics -
     https://developer.github.com/v3/repos/community/#retrieve-community-profile-metrics
 
-  repos get-readme --token=STRING --owner=STRING --repo=STRING
+  repos get-readme --token=STRING --repo=STRING
     Get the README -
     https://developer.github.com/v3/repos/contents/#get-the-readme
 
-  repos get-contents --token=STRING --owner=STRING --repo=STRING --path=STRING
+  repos get-contents --token=STRING --repo=STRING --path=STRING
     Get contents - https://developer.github.com/v3/repos/contents/#get-contents
 
-  repos get-archive-link --token=STRING --owner=STRING --repo=STRING --archive_format=STRING --ref=STRING
+  repos get-archive-link --token=STRING --repo=STRING --archive_format=STRING --ref=STRING
     Get archive link -
     https://developer.github.com/v3/repos/contents/#get-archive-link
 
-  repos list-deploy-keys --token=STRING --owner=STRING --repo=STRING
+  repos list-deploy-keys --token=STRING --repo=STRING
     List deploy keys -
     https://developer.github.com/v3/repos/keys/#list-deploy-keys
 
-  repos get-deploy-key --token=STRING --owner=STRING --repo=STRING --key_id=INT-64
+  repos get-deploy-key --token=STRING --repo=STRING --key_id=INT-64
     Get a deploy key -
     https://developer.github.com/v3/repos/keys/#get-a-deploy-key
 
-  repos add-deploy-key --token=STRING --owner=STRING --repo=STRING --key=STRING
+  repos add-deploy-key --token=STRING --repo=STRING --key=STRING
     Add a new deploy key -
     https://developer.github.com/v3/repos/keys/#add-a-new-deploy-key
 
-  repos remove-deploy-key --token=STRING --owner=STRING --repo=STRING --key_id=INT-64
+  repos remove-deploy-key --token=STRING --repo=STRING --key_id=INT-64
     Remove a deploy key -
     https://developer.github.com/v3/repos/keys/#remove-a-deploy-key
 
-  repos list-deployments --token=STRING --owner=STRING --repo=STRING
+  repos list-deployments --token=STRING --repo=STRING
     List deployments -
     https://developer.github.com/v3/repos/deployments/#list-deployments
 
-  repos get-deployment --token=STRING --owner=STRING --repo=STRING --deployment_id=INT-64
+  repos get-deployment --token=STRING --repo=STRING --deployment_id=INT-64
     Get a single deployment -
     https://developer.github.com/v3/repos/deployments/#get-a-single-deployment
 
-  repos create-deployment --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  repos create-deployment --token=STRING --repo=STRING --ref=STRING
     Create a deployment -
     https://developer.github.com/v3/repos/deployments/#create-a-deployment
 
-  repos list-deployment-statuses --token=STRING --owner=STRING --repo=STRING --deployment_id=INT-64
+  repos list-deployment-statuses --token=STRING --repo=STRING --deployment_id=INT-64
     List deployment statuses -
     https://developer.github.com/v3/repos/deployments/#list-deployment-statuses
 
-  repos get-deployment-status --token=STRING --owner=STRING --repo=STRING --deployment_id=INT-64 --status_id=INT-64
+  repos get-deployment-status --token=STRING --repo=STRING --deployment_id=INT-64 --status_id=INT-64
     Get a single deployment status -
     https://developer.github.com/v3/repos/deployments/#get-a-single-deployment-status
 
-  repos create-deployment-status --token=STRING --owner=STRING --repo=STRING --deployment_id=INT-64 --state=STRING
+  repos create-deployment-status --token=STRING --repo=STRING --deployment_id=INT-64 --state=STRING
     Create a deployment status -
     https://developer.github.com/v3/repos/deployments/#create-a-deployment-status
 
-  repos list-downloads --token=STRING --owner=STRING --repo=STRING
+  repos list-downloads --token=STRING --repo=STRING
     List downloads for a repository -
     https://developer.github.com/v3/repos/downloads/#list-downloads-for-a-repository
 
-  repos get-download --token=STRING --owner=STRING --repo=STRING --download_id=INT-64
+  repos get-download --token=STRING --repo=STRING --download_id=INT-64
     Get a single download -
     https://developer.github.com/v3/repos/downloads/#get-a-single-download
 
-  repos delete-download --token=STRING --owner=STRING --repo=STRING --download_id=INT-64
+  repos delete-download --token=STRING --repo=STRING --download_id=INT-64
     Delete a download -
     https://developer.github.com/v3/repos/downloads/#delete-a-download
 
-  repos list-forks --token=STRING --owner=STRING --repo=STRING
+  repos list-forks --token=STRING --repo=STRING
     List forks - https://developer.github.com/v3/repos/forks/#list-forks
 
-  repos create-fork --token=STRING --owner=STRING --repo=STRING
+  repos create-fork --token=STRING --repo=STRING
     Create a fork - https://developer.github.com/v3/repos/forks/#create-a-fork
 
-  repos list-invitations --token=STRING --owner=STRING --repo=STRING
+  repos list-invitations --token=STRING --repo=STRING
     List invitations for a repository -
     https://developer.github.com/v3/repos/invitations/#list-invitations-for-a-repository
 
-  repos delete-invitation --token=STRING --owner=STRING --repo=STRING --invitation_id=INT-64
+  repos delete-invitation --token=STRING --repo=STRING --invitation_id=INT-64
     Delete a repository invitation -
     https://developer.github.com/v3/repos/invitations/#delete-a-repository-invitation
 
-  repos update-invitation --token=STRING --owner=STRING --repo=STRING --invitation_id=INT-64
+  repos update-invitation --token=STRING --repo=STRING --invitation_id=INT-64
     Update a repository invitation -
     https://developer.github.com/v3/repos/invitations/#update-a-repository-invitation
 
@@ -1560,138 +1560,138 @@ Commands:
     Decline a repository invitation -
     https://developer.github.com/v3/repos/invitations/#decline-a-repository-invitation
 
-  repos merge --token=STRING --owner=STRING --repo=STRING --base=STRING --head=STRING
+  repos merge --token=STRING --repo=STRING --base=STRING --head=STRING
     Perform a merge -
     https://developer.github.com/v3/repos/merging/#perform-a-merge
 
-  repos get-pages --token=STRING --mister-fantastic-preview --owner=STRING --repo=STRING
+  repos get-pages --token=STRING --mister-fantastic-preview --repo=STRING
     Get information about a Pages site -
     https://developer.github.com/v3/repos/pages/#get-information-about-a-pages-site
 
-  repos update-information-about-pages-site --token=STRING --mister-fantastic-preview --owner=STRING --repo=STRING
+  repos update-information-about-pages-site --token=STRING --mister-fantastic-preview --repo=STRING
     Update information about a Pages site -
     https://developer.github.com/v3/repos/pages/#update-information-about-a-pages-site
 
-  repos request-page-build --token=STRING --mister-fantastic-preview --owner=STRING --repo=STRING
+  repos request-page-build --token=STRING --mister-fantastic-preview --repo=STRING
     Request a page build -
     https://developer.github.com/v3/repos/pages/#request-a-page-build
 
-  repos list-pages-builds --token=STRING --owner=STRING --repo=STRING
+  repos list-pages-builds --token=STRING --repo=STRING
     List Pages builds -
     https://developer.github.com/v3/repos/pages/#list-pages-builds
 
-  repos get-latest-pages-build --token=STRING --owner=STRING --repo=STRING
+  repos get-latest-pages-build --token=STRING --repo=STRING
     Get latest Pages build -
     https://developer.github.com/v3/repos/pages/#get-latest-pages-build
 
-  repos get-pages-build --token=STRING --owner=STRING --repo=STRING --build_id=INT-64
+  repos get-pages-build --token=STRING --repo=STRING --build_id=INT-64
     Get a specific Pages build -
     https://developer.github.com/v3/repos/pages/#get-a-specific-pages-build
 
-  repos list-releases --token=STRING --owner=STRING --repo=STRING
+  repos list-releases --token=STRING --repo=STRING
     List releases for a repository -
     https://developer.github.com/v3/repos/releases/#list-releases-for-a-repository
 
-  repos get-release --token=STRING --owner=STRING --repo=STRING --release_id=INT-64
+  repos get-release --token=STRING --repo=STRING --release_id=INT-64
     Get a single release -
     https://developer.github.com/v3/repos/releases/#get-a-single-release
 
-  repos get-latest-release --token=STRING --owner=STRING --repo=STRING
+  repos get-latest-release --token=STRING --repo=STRING
     Get the latest release -
     https://developer.github.com/v3/repos/releases/#get-the-latest-release
 
-  repos get-release-by-tag --token=STRING --owner=STRING --repo=STRING --tag=STRING
+  repos get-release-by-tag --token=STRING --repo=STRING --tag=STRING
     Get a release by tag name -
     https://developer.github.com/v3/repos/releases/#get-a-release-by-tag-name
 
-  repos create-release --token=STRING --owner=STRING --repo=STRING --tag_name=STRING
+  repos create-release --token=STRING --repo=STRING --tag_name=STRING
     Create a release -
     https://developer.github.com/v3/repos/releases/#create-a-release
 
-  repos edit-release --token=STRING --owner=STRING --repo=STRING --release_id=INT-64
+  repos edit-release --token=STRING --repo=STRING --release_id=INT-64
     Edit a release -
     https://developer.github.com/v3/repos/releases/#edit-a-release
 
-  repos delete-release --token=STRING --owner=STRING --repo=STRING --release_id=INT-64
+  repos delete-release --token=STRING --repo=STRING --release_id=INT-64
     Delete a release -
     https://developer.github.com/v3/repos/releases/#delete-a-release
 
-  repos list-assets-for-release --token=STRING --owner=STRING --repo=STRING --release_id=INT-64
+  repos list-assets-for-release --token=STRING --repo=STRING --release_id=INT-64
     List assets for a release -
     https://developer.github.com/v3/repos/releases/#list-assets-for-a-release
 
-  repos get-release-asset --token=STRING --owner=STRING --repo=STRING --asset_id=INT-64
+  repos get-release-asset --token=STRING --repo=STRING --asset_id=INT-64
     Get a single release asset -
     https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
 
-  repos edit-release-asset --token=STRING --owner=STRING --repo=STRING --asset_id=INT-64
+  repos edit-release-asset --token=STRING --repo=STRING --asset_id=INT-64
     Edit a release asset -
     https://developer.github.com/v3/repos/releases/#edit-a-release-asset
 
-  repos delete-release-asset --token=STRING --owner=STRING --repo=STRING --asset_id=INT-64
+  repos delete-release-asset --token=STRING --repo=STRING --asset_id=INT-64
     Delete a release asset -
     https://developer.github.com/v3/repos/releases/#delete-a-release-asset
 
-  repos get-contributors-stats --token=STRING --owner=STRING --repo=STRING
+  repos get-contributors-stats --token=STRING --repo=STRING
     Get contributors list with additions, deletions, and commit counts -
     https://developer.github.com/v3/repos/statistics/#get-contributors-list-with-additions-deletions-and-commit-counts
 
-  repos get-commit-activity-stats --token=STRING --owner=STRING --repo=STRING
+  repos get-commit-activity-stats --token=STRING --repo=STRING
     Get the last year of commit activity data -
     https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
 
-  repos get-code-frequency-stats --token=STRING --owner=STRING --repo=STRING
+  repos get-code-frequency-stats --token=STRING --repo=STRING
     Get the number of additions and deletions per week -
     https://developer.github.com/v3/repos/statistics/#get-the-number-of-additions-and-deletions-per-week
 
-  repos get-participation-stats --token=STRING --owner=STRING --repo=STRING
+  repos get-participation-stats --token=STRING --repo=STRING
     Get the weekly commit count for the repository owner and everyone else -
     https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else
 
-  repos get-punch-card-stats --token=STRING --owner=STRING --repo=STRING
+  repos get-punch-card-stats --token=STRING --repo=STRING
     Get the number of commits per hour in each day -
     https://developer.github.com/v3/repos/statistics/#get-the-number-of-commits-per-hour-in-each-day
 
-  repos create-status --token=STRING --owner=STRING --repo=STRING --sha=STRING --state=STRING
+  repos create-status --token=STRING --repo=STRING --sha=STRING --state=STRING
     Create a status -
     https://developer.github.com/v3/repos/statuses/#create-a-status
 
-  repos list-statuses-for-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  repos list-statuses-for-ref --token=STRING --repo=STRING --ref=STRING
     List statuses for a specific ref -
     https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
 
-  repos get-combined-status-for-ref --token=STRING --owner=STRING --repo=STRING --ref=STRING
+  repos get-combined-status-for-ref --token=STRING --repo=STRING --ref=STRING
     Get the combined status for a specific ref -
     https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 
-  repos get-top-referrers --token=STRING --owner=STRING --repo=STRING
+  repos get-top-referrers --token=STRING --repo=STRING
     List referrers -
     https://developer.github.com/v3/repos/traffic/#list-referrers
 
-  repos get-top-paths --token=STRING --owner=STRING --repo=STRING
+  repos get-top-paths --token=STRING --repo=STRING
     List paths - https://developer.github.com/v3/repos/traffic/#list-paths
 
-  repos get-views --token=STRING --owner=STRING --repo=STRING
+  repos get-views --token=STRING --repo=STRING
     Views - https://developer.github.com/v3/repos/traffic/#views
 
-  repos get-clones --token=STRING --owner=STRING --repo=STRING
+  repos get-clones --token=STRING --repo=STRING
     Clones - https://developer.github.com/v3/repos/traffic/#clones
 
-  repos list-hooks --token=STRING --owner=STRING --repo=STRING
+  repos list-hooks --token=STRING --repo=STRING
     List hooks - https://developer.github.com/v3/repos/hooks/#list-hooks
 
-  repos get-hook --token=STRING --owner=STRING --repo=STRING --hook_id=INT-64
+  repos get-hook --token=STRING --repo=STRING --hook_id=INT-64
     Get single hook -
     https://developer.github.com/v3/repos/hooks/#get-single-hook
 
-  repos test-push-hook --token=STRING --owner=STRING --repo=STRING --hook_id=INT-64
+  repos test-push-hook --token=STRING --repo=STRING --hook_id=INT-64
     Test a push hook -
     https://developer.github.com/v3/repos/hooks/#test-a-push-hook
 
-  repos ping-hook --token=STRING --owner=STRING --repo=STRING --hook_id=INT-64
+  repos ping-hook --token=STRING --repo=STRING --hook_id=INT-64
     Ping a hook - https://developer.github.com/v3/repos/hooks/#ping-a-hook
 
-  repos delete-hook --token=STRING --owner=STRING --repo=STRING --hook_id=INT-64
+  repos delete-hook --token=STRING --repo=STRING --hook_id=INT-64
     Delete a hook - https://developer.github.com/v3/repos/hooks/#delete-a-hook
 
   scim list-provisioned-identities --token=STRING --cloud-9-preview --org=STRING
@@ -1774,15 +1774,15 @@ Commands:
   teams list-repos --token=STRING --team_id=INT-64
     List team repos - https://developer.github.com/v3/teams/#list-team-repos
 
-  teams check-manages-repo --token=STRING --team_id=INT-64 --owner=STRING --repo=STRING
+  teams check-manages-repo --token=STRING --team_id=INT-64 --repo=STRING
     Check if a team manages a repository -
     https://developer.github.com/v3/teams/#check-if-a-team-manages-a-repository
 
-  teams add-or-update-repo --token=STRING --team_id=INT-64 --owner=STRING --repo=STRING
+  teams add-or-update-repo --token=STRING --team_id=INT-64 --repo=STRING
     Add or update team repository -
     https://developer.github.com/v3/teams/#add-or-update-team-repository
 
-  teams remove-repo --token=STRING --team_id=INT-64 --owner=STRING --repo=STRING
+  teams remove-repo --token=STRING --team_id=INT-64 --repo=STRING
     Remove team repository -
     https://developer.github.com/v3/teams/#remove-team-repository
 

--- a/buildtool/generator/generator.go
+++ b/buildtool/generator/generator.go
@@ -172,7 +172,17 @@ func Generate(routesPath, outputPath string, fs afero.Fs) {
 					ValueField:   previewParamName,
 				})
 			}
-			for _, param := range route.Params {
+			for i := 0 ; i < len(route.Params); i++ {
+				param := route.Params[i]
+				// We want owner to be optional so that repo can be set as part of repo like
+				//  --repo=owner/repo
+				if param.Name == "owner" {
+					if len(route.Params) > i {
+						if route.Params[i+1].Name == "repo" {
+							param.Required = false
+						}
+					}
+				}
 				paramName := ToArgName(param.Name)
 				paramType, ok := paramTypes[param.Type]
 				if !ok {

--- a/buildtool/generator/testdata/generated/activitycmd.go
+++ b/buildtool/generator/testdata/generated/activitycmd.go
@@ -57,7 +57,7 @@ func (c *ActivityListPublicEventsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListRepoEventsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -75,7 +75,7 @@ func (c *ActivityListRepoEventsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListPublicEventsForRepoNetworkCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -223,7 +223,7 @@ func (c *ActivityListNotificationsCmd) Run(isValueSetMap map[string]bool) error 
 
 type ActivityListNotificationsForRepoCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	All           bool   "name:\"all\" help:\"If `true`, show notifications marked as read.\""
 	Participating bool   "name:\"participating\" help:\"If `true`, only shows notifications in which the user is directly participating or mentioned.\""
@@ -261,7 +261,7 @@ func (c *ActivityMarkAsReadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityMarkNotificationsAsReadForRepoCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	LastReadAt string "name:\"last_read_at\" help:\"Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.\""
 }
@@ -339,7 +339,7 @@ func (c *ActivityDeleteThreadSubscriptionCmd) Run(isValueSetMap map[string]bool)
 
 type ActivityListStargazersForRepoCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -395,7 +395,7 @@ func (c *ActivityListReposStarredByAuthenticatedUserCmd) Run(isValueSetMap map[s
 
 type ActivityCheckStarringRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -409,7 +409,7 @@ func (c *ActivityCheckStarringRepoCmd) Run(isValueSetMap map[string]bool) error 
 
 type ActivityStarRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -423,7 +423,7 @@ func (c *ActivityStarRepoCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityUnstarRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -437,7 +437,7 @@ func (c *ActivityUnstarRepoCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListWatchersForRepoCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -485,7 +485,7 @@ func (c *ActivityListWatchedReposForAuthenticatedUserCmd) Run(isValueSetMap map[
 
 type ActivityGetRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -499,7 +499,7 @@ func (c *ActivityGetRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ActivitySetRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Subscribed bool   `name:"subscribed" help:"Determines if notifications should be received from this repository."`
 	Ignored    bool   `name:"ignored" help:"Determines if all notifications should be blocked from this repository."`
@@ -517,7 +517,7 @@ func (c *ActivitySetRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ActivityDeleteRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -531,7 +531,7 @@ func (c *ActivityDeleteRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) e
 
 type ActivityCheckWatchingRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -545,7 +545,7 @@ func (c *ActivityCheckWatchingRepoLegacyCmd) Run(isValueSetMap map[string]bool) 
 
 type ActivityWatchRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -559,7 +559,7 @@ func (c *ActivityWatchRepoLegacyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityStopWatchingRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 

--- a/buildtool/generator/testdata/generated/appscmd.go
+++ b/buildtool/generator/testdata/generated/appscmd.go
@@ -130,7 +130,7 @@ func (c *AppsFindOrgInstallationCmd) Run(isValueSetMap map[string]bool) error {
 type AppsFindRepoInstallationCmd struct {
 	internal.BaseCmd
 	MachineMan bool   "name:\"machine-man-preview\" required:\"\" help:\"**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 

--- a/buildtool/generator/testdata/generated/checkscmd.go
+++ b/buildtool/generator/testdata/generated/checkscmd.go
@@ -18,7 +18,7 @@ type ChecksCmd struct {
 type ChecksListForRefCmd struct {
 	internal.BaseCmd
 	Antiope   bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Ref       string `required:"" name:"ref"`
 	CheckName string "name:\"check_name\" help:\"Returns check runs with the specified `name`.\""
@@ -46,7 +46,7 @@ func (c *ChecksListForRefCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListForSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 	CheckName    string "name:\"check_name\" help:\"Returns check runs with the specified `name`.\""
@@ -74,7 +74,7 @@ func (c *ChecksListForSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksGetCmd struct {
 	internal.BaseCmd
 	Antiope    bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	CheckRunId int64  `required:"" name:"check_run_id"`
 }
@@ -92,7 +92,7 @@ func (c *ChecksGetCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListAnnotationsCmd struct {
 	internal.BaseCmd
 	Antiope    bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	CheckRunId int64  `required:"" name:"check_run_id"`
 	PerPage    int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -114,7 +114,7 @@ func (c *ChecksListAnnotationsCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksGetSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 }
@@ -132,7 +132,7 @@ func (c *ChecksGetSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListSuitesForRefCmd struct {
 	internal.BaseCmd
 	Antiope   bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Ref       string `required:"" name:"ref"`
 	AppId     int64  "name:\"app_id\" help:\"Filters check suites by GitHub App `id`.\""
@@ -158,7 +158,7 @@ func (c *ChecksListSuitesForRefCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksCreateSuiteCmd struct {
 	internal.BaseCmd
 	Antiope bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	HeadSha string `required:"" name:"head_sha" help:"The sha of the head commit."`
 }
@@ -176,7 +176,7 @@ func (c *ChecksCreateSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksRerequestSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 }

--- a/buildtool/generator/testdata/generated/codesofconductcmd.go
+++ b/buildtool/generator/testdata/generated/codesofconductcmd.go
@@ -39,7 +39,7 @@ func (c *CodesOfConductGetConductCodeCmd) Run(isValueSetMap map[string]bool) err
 type CodesOfConductGetForRepoCmd struct {
 	internal.BaseCmd
 	ScarletWitch bool   "name:\"scarlet-witch-preview\" required:\"\" help:\"**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 }
 

--- a/buildtool/generator/testdata/generated/gitcmd.go
+++ b/buildtool/generator/testdata/generated/gitcmd.go
@@ -19,7 +19,7 @@ type GitCmd struct {
 
 type GitGetBlobCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	FileSha string `required:"" name:"file_sha"`
 }
@@ -35,7 +35,7 @@ func (c *GitGetBlobCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitCreateBlobCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Content  string `required:"" name:"content" help:"The new blob's content."`
 	Encoding string "name:\"encoding\" help:\"The encoding used for `content`. Currently, `'utf-8'` and `'base64'` are supported.\""
@@ -53,7 +53,7 @@ func (c *GitCreateBlobCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetCommitCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommitSha string `required:"" name:"commit_sha"`
 }
@@ -69,7 +69,7 @@ func (c *GitGetCommitCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string "required:\"\" name:\"ref\" help:\"Must be formatted as `heads/branch`, not just `branch`\""
 }
@@ -85,7 +85,7 @@ func (c *GitGetRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitListRefsCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Namespace string "name:\"namespace\" help:\"Filter by sub-namespace (reference prefix). Most commen examples would be `'heads/'` and `'tags/'` to retrieve branches or tags\""
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -105,7 +105,7 @@ func (c *GitListRefsCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitCreateRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string "required:\"\" name:\"ref\" help:\"The name of the fully qualified reference (ie: `refs/heads/master`). If it doesn't start with 'refs' and have at least two slashes, it will be rejected.\""
 	Sha   string `required:"" name:"sha" help:"The SHA1 value for this reference."`
@@ -123,7 +123,7 @@ func (c *GitCreateRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitUpdateRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 	Sha   string `required:"" name:"sha" help:"The SHA1 value to set this reference to"`
@@ -143,7 +143,7 @@ func (c *GitUpdateRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitDeleteRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -159,7 +159,7 @@ func (c *GitDeleteRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetTagCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	TagSha string `required:"" name:"tag_sha"`
 }
@@ -175,7 +175,7 @@ func (c *GitGetTagCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetTreeCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	TreeSha   string `required:"" name:"tree_sha"`
 	Recursive int64  `name:"recursive"`

--- a/buildtool/generator/testdata/generated/issuescmd.go
+++ b/buildtool/generator/testdata/generated/issuescmd.go
@@ -149,7 +149,7 @@ type IssuesListForRepoCmd struct {
 	Symmetra     bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue is opened via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Milestone    string "name:\"milestone\" help:\"If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.\""
 	State        string "name:\"state\" help:\"Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.\""
@@ -190,7 +190,7 @@ type IssuesGetCmd struct {
 	internal.BaseCmd
 	Symmetra     bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 }
@@ -209,7 +209,7 @@ func (c *IssuesGetCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesCreateCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Title     string   `required:"" name:"title" help:"The title of the issue."`
 	Body      string   `name:"body" help:"The contents of the issue."`
@@ -237,7 +237,7 @@ func (c *IssuesCreateCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesEditCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Title     string   `name:"title" help:"The title of the issue."`
@@ -269,7 +269,7 @@ func (c *IssuesEditCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesLockCmd struct {
 	internal.BaseCmd
 	SailorV    bool   "name:\"sailor-v-preview\" help:\"**Note:** You can now add a reason when you lock an issue. This feature is currently available for developers to preview. See the [blog post](/changes/2018-01-10-lock-reason-api-preview) for full details. To access this feature, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.sailor-v-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Number     int64  `required:"" name:"number"`
 	LockReason string "name:\"lock_reason\" help:\"The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:  \n\\* `off-topic`  \n\\* `too heated`  \n\\* `resolved`  \n\\* `spam`\""
@@ -288,7 +288,7 @@ func (c *IssuesLockCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesUnlockCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -304,7 +304,7 @@ func (c *IssuesUnlockCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesListAssigneesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -322,7 +322,7 @@ func (c *IssuesListAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCheckAssigneeCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Assignee string `required:"" name:"assignee"`
 }
@@ -339,7 +339,7 @@ func (c *IssuesCheckAssigneeCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesAddAssigneesCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Assignees []string `name:"assignees" help:"Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._"`
@@ -359,7 +359,7 @@ func (c *IssuesAddAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesRemoveAssigneesCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Assignees []string `name:"assignees" help:"Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._"`
@@ -379,7 +379,7 @@ func (c *IssuesRemoveAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Since        string "name:\"since\" help:\"Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.\""
@@ -403,7 +403,7 @@ func (c *IssuesListCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListCommentsForRepoCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Sort         string "name:\"sort\" help:\"Either `created` or `updated`.\""
 	Direction    string "name:\"direction\" help:\"Either `asc` or `desc`. Ignored without the `sort` parameter.\""
@@ -426,7 +426,7 @@ type IssuesGetCommentCmd struct {
 	internal.BaseCmd
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue comment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -448,7 +448,7 @@ func (c *IssuesGetCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCreateCommentCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 	Body   string `required:"" name:"body" help:"The contents of the comment."`
@@ -466,7 +466,7 @@ func (c *IssuesCreateCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesEditCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The contents of the comment."`
@@ -484,7 +484,7 @@ func (c *IssuesEditCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -501,7 +501,7 @@ func (c *IssuesDeleteCommentCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListEventsCmd struct {
 	internal.BaseCmd
 	Starfox bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -524,7 +524,7 @@ type IssuesListEventsForRepoCmd struct {
 	internal.BaseCmd
 	Starfox  bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page     int64  `name:"page" help:"Page number of the results to fetch."`
@@ -547,7 +547,7 @@ type IssuesGetEventCmd struct {
 	Starfox    bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
 	Symmetra   bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	MachineMan bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue event is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	EventId    int64  `required:"" name:"event_id"`
 }
@@ -567,7 +567,7 @@ func (c *IssuesGetEventCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsForRepoCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page     int64  `name:"page" help:"Page number of the results to fetch."`
@@ -587,7 +587,7 @@ func (c *IssuesListLabelsForRepoCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesGetLabelCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Name     string `required:"" name:"name"`
 }
@@ -605,7 +605,7 @@ func (c *IssuesGetLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesCreateLabelCmd struct {
 	internal.BaseCmd
 	Symmetra    bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Name        string "required:\"\" name:\"name\" help:\"The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png ':strawberry:'). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).\""
 	Color       string "required:\"\" name:\"color\" help:\"The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.\""
@@ -627,7 +627,7 @@ func (c *IssuesCreateLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesUpdateLabelCmd struct {
 	internal.BaseCmd
 	Symmetra    bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	CurrentName string `required:"" name:"current_name"`
 	Name        string "name:\"name\" help:\"The new name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png ':strawberry:'). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).\""
@@ -650,7 +650,7 @@ func (c *IssuesUpdateLabelCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteLabelCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Name  string `required:"" name:"name"`
 }
@@ -667,7 +667,7 @@ func (c *IssuesDeleteLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsOnIssueCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -689,7 +689,7 @@ func (c *IssuesListLabelsOnIssueCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesAddLabelsCmd struct {
 	internal.BaseCmd
 	Symmetra bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Number   int64    `required:"" name:"number"`
 	Labels   []string "required:\"\" name:\"labels\" help:\"The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.\""
@@ -709,7 +709,7 @@ func (c *IssuesAddLabelsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesRemoveLabelCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	Name     string `required:"" name:"name"`
@@ -729,7 +729,7 @@ func (c *IssuesRemoveLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesReplaceLabelsCmd struct {
 	internal.BaseCmd
 	Symmetra bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Number   int64    `required:"" name:"number"`
 	Labels   []string "name:\"labels\" help:\"The names of the labels to add to the issue. You can pass an empty array to remove all labels. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.\""
@@ -748,7 +748,7 @@ func (c *IssuesReplaceLabelsCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesRemoveLabelsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -765,7 +765,7 @@ func (c *IssuesRemoveLabelsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsForMilestoneCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -786,7 +786,7 @@ func (c *IssuesListLabelsForMilestoneCmd) Run(isValueSetMap map[string]bool) err
 
 type IssuesListMilestonesForRepoCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	State     string "name:\"state\" help:\"The state of the milestone. Either `open`, `closed`, or `all`.\""
 	Sort      string "name:\"sort\" help:\"What to sort results by. Either `due_on` or `completeness`.\""
@@ -810,7 +810,7 @@ func (c *IssuesListMilestonesForRepoCmd) Run(isValueSetMap map[string]bool) erro
 
 type IssuesGetMilestoneCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -826,7 +826,7 @@ func (c *IssuesGetMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCreateMilestoneCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Title       string `required:"" name:"title" help:"The title of the milestone."`
 	State       string "name:\"state\" help:\"The state of the milestone. Either `open` or `closed`.\""
@@ -848,7 +848,7 @@ func (c *IssuesCreateMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesUpdateMilestoneCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Number      int64  `required:"" name:"number"`
 	Title       string `name:"title" help:"The title of the milestone."`
@@ -872,7 +872,7 @@ func (c *IssuesUpdateMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteMilestoneCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -890,7 +890,7 @@ type IssuesListEventsForTimelineCmd struct {
 	internal.BaseCmd
 	Mockingbird bool   "name:\"mockingbird-preview\" required:\"\" help:\"The API to get issue timeline events is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-23-timeline-preview-api/) for full details. To access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mockingbird-preview\n\n```\""
 	Starfox     bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Number      int64  `required:"" name:"number"`
 	PerPage     int64  `name:"per_page" help:"Results per page (max 100)"`

--- a/buildtool/generator/testdata/generated/licensescmd.go
+++ b/buildtool/generator/testdata/generated/licensescmd.go
@@ -34,7 +34,7 @@ func (c *LicensesGetCmd) Run(isValueSetMap map[string]bool) error {
 
 type LicensesGetForRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 

--- a/buildtool/generator/testdata/generated/migrationscmd.go
+++ b/buildtool/generator/testdata/generated/migrationscmd.go
@@ -132,7 +132,7 @@ func (c *MigrationsUnlockRepoForOrgCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsStartImportCmd struct {
 	internal.BaseCmd
 	BarredRock  bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	VcsUrl      string `required:"" name:"vcs_url" help:"The URL of the originating repository."`
 	Vcs         string "name:\"vcs\" help:\"The originating VCS type. Can be one of `subversion`, `git`, `mercurial`, or `tfvc`. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response.\""
@@ -158,7 +158,7 @@ func (c *MigrationsStartImportCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsGetImportProgressCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 
@@ -174,7 +174,7 @@ func (c *MigrationsGetImportProgressCmd) Run(isValueSetMap map[string]bool) erro
 type MigrationsUpdateImportCmd struct {
 	internal.BaseCmd
 	BarredRock  bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	VcsUsername string `name:"vcs_username" help:"The username to provide to the originating repository."`
 	VcsPassword string `name:"vcs_password" help:"The password to provide to the originating repository."`
@@ -194,7 +194,7 @@ func (c *MigrationsUpdateImportCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsGetCommitAuthorsCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Since      string "name:\"since\" help:\"Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the `raw` step.\""
 }
@@ -212,7 +212,7 @@ func (c *MigrationsGetCommitAuthorsCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsMapCommitAuthorCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	AuthorId   int64  `required:"" name:"author_id"`
 	Email      string `name:"email" help:"The new Git author email."`
@@ -234,7 +234,7 @@ func (c *MigrationsMapCommitAuthorCmd) Run(isValueSetMap map[string]bool) error 
 type MigrationsSetLfsPreferenceCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	UseLfs     string "required:\"\" name:\"use_lfs\" help:\"Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import).\""
 }
@@ -252,7 +252,7 @@ func (c *MigrationsSetLfsPreferenceCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsGetLargeFilesCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 
@@ -268,7 +268,7 @@ func (c *MigrationsGetLargeFilesCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsCancelImportCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 

--- a/buildtool/generator/testdata/generated/projectscmd.go
+++ b/buildtool/generator/testdata/generated/projectscmd.go
@@ -33,7 +33,7 @@ type ProjectsCmd struct {
 type ProjectsListForRepoCmd struct {
 	internal.BaseCmd
 	Inertia bool   "name:\"inertia-preview\" required:\"\" help:\"The Projects API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-10-27-changes-to-projects-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.inertia-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	State   string "name:\"state\" help:\"Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -93,7 +93,7 @@ func (c *ProjectsGetCmd) Run(isValueSetMap map[string]bool) error {
 type ProjectsCreateForRepoCmd struct {
 	internal.BaseCmd
 	Inertia bool   "name:\"inertia-preview\" required:\"\" help:\"The Projects API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-10-27-changes-to-projects-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.inertia-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Name    string `required:"" name:"name" help:"The name of the project."`
 	Body    string `name:"body" help:"The body of the project."`

--- a/buildtool/generator/testdata/generated/pullscmd.go
+++ b/buildtool/generator/testdata/generated/pullscmd.go
@@ -35,7 +35,7 @@ type PullsCmd struct {
 type PullsListCmd struct {
 	internal.BaseCmd
 	Symmetra  bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	State     string "name:\"state\" help:\"Either `open`, `closed`, or `all` to filter by state.\""
 	Head      string "name:\"head\" help:\"Filter pulls by head user and branch name in the format of `user:ref-name`. Example: `github:new-script-format`.\""
@@ -65,7 +65,7 @@ func (c *PullsListCmd) Run(isValueSetMap map[string]bool) error {
 type PullsGetCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 }
@@ -83,7 +83,7 @@ func (c *PullsGetCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Title               string `required:"" name:"title" help:"The title of the pull request."`
 	Head                string "required:\"\" name:\"head\" help:\"The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.\""
@@ -109,7 +109,7 @@ func (c *PullsCreateCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateFromIssueCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Issue               int64  `required:"" name:"issue" help:"The issue number in this repository to turn into a Pull Request."`
 	Head                string "required:\"\" name:\"head\" help:\"The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.\""
@@ -133,7 +133,7 @@ func (c *PullsCreateFromIssueCmd) Run(isValueSetMap map[string]bool) error {
 type PullsUpdateCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Number              int64  `required:"" name:"number"`
 	Title               string `name:"title" help:"The title of the pull request."`
@@ -160,7 +160,7 @@ func (c *PullsUpdateCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListCommitsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -180,7 +180,7 @@ func (c *PullsListCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListFilesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -200,7 +200,7 @@ func (c *PullsListFilesCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCheckIfMergedCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -216,7 +216,7 @@ func (c *PullsCheckIfMergedCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsMergeCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	Number        int64  `required:"" name:"number"`
 	CommitTitle   string `name:"commit_title" help:"Title for the automatic commit message."`
@@ -240,7 +240,7 @@ func (c *PullsMergeCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListReviewsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -260,7 +260,7 @@ func (c *PullsListReviewsCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsGetReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -278,7 +278,7 @@ func (c *PullsGetReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeletePendingReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -296,7 +296,7 @@ func (c *PullsDeletePendingReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsGetCommentsForReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -318,7 +318,7 @@ func (c *PullsGetCommentsForReviewCmd) Run(isValueSetMap map[string]bool) error 
 
 type PullsSubmitReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -340,7 +340,7 @@ func (c *PullsSubmitReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDismissReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -361,7 +361,7 @@ func (c *PullsDismissReviewCmd) Run(isValueSetMap map[string]bool) error {
 type PullsListCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Sort         string "name:\"sort\" help:\"Can be either `created` or `updated` comments.\""
@@ -389,7 +389,7 @@ func (c *PullsListCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type PullsListCommentsForRepoCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Sort         string "name:\"sort\" help:\"Can be either `created` or `updated` comments.\""
 	Direction    string "name:\"direction\" help:\"Can be either `asc` or `desc`. Ignored without `sort` parameter.\""
@@ -415,7 +415,7 @@ func (c *PullsListCommentsForRepoCmd) Run(isValueSetMap map[string]bool) error {
 type PullsGetCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 }
@@ -432,7 +432,7 @@ func (c *PullsGetCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCreateCommentCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	Body     string `required:"" name:"body" help:"The text of the comment."`
@@ -456,7 +456,7 @@ func (c *PullsCreateCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCreateCommentReplyCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Number    int64  `required:"" name:"number"`
 	Body      string `required:"" name:"body" help:"The text of the comment."`
@@ -476,7 +476,7 @@ func (c *PullsCreateCommentReplyCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsEditCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The text of the comment."`
@@ -494,7 +494,7 @@ func (c *PullsEditCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeleteCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -510,7 +510,7 @@ func (c *PullsDeleteCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListReviewRequestsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -531,7 +531,7 @@ func (c *PullsListReviewRequestsCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateReviewRequestCmd struct {
 	internal.BaseCmd
 	Symmetra      bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner         string   `required:"" name:"owner"`
+	Owner         string   `name:"owner"`
 	Repo          string   `required:"" name:"repo"`
 	Number        int64    `required:"" name:"number"`
 	Reviewers     []string "name:\"reviewers\" help:\"An array of user `login`s that will be requested.\""
@@ -552,7 +552,7 @@ func (c *PullsCreateReviewRequestCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeleteReviewRequestCmd struct {
 	internal.BaseCmd
-	Owner         string   `required:"" name:"owner"`
+	Owner         string   `name:"owner"`
 	Repo          string   `required:"" name:"repo"`
 	Number        int64    `required:"" name:"number"`
 	Reviewers     []string "name:\"reviewers\" help:\"An array of user `login`s that will be removed.\""

--- a/buildtool/generator/testdata/generated/reactionscmd.go
+++ b/buildtool/generator/testdata/generated/reactionscmd.go
@@ -23,7 +23,7 @@ type ReactionsCmd struct {
 type ReactionsListForCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a commit comment."`
@@ -47,7 +47,7 @@ func (c *ReactionsListForCommitCommentCmd) Run(isValueSetMap map[string]bool) er
 type ReactionsCreateForCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the commit comment."`
@@ -67,7 +67,7 @@ func (c *ReactionsCreateForCommitCommentCmd) Run(isValueSetMap map[string]bool) 
 type ReactionsListForIssueCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue."`
@@ -91,7 +91,7 @@ func (c *ReactionsListForIssueCmd) Run(isValueSetMap map[string]bool) error {
 type ReactionsCreateForIssueCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue."`
@@ -111,7 +111,7 @@ func (c *ReactionsCreateForIssueCmd) Run(isValueSetMap map[string]bool) error {
 type ReactionsListForIssueCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue comment."`
@@ -135,7 +135,7 @@ func (c *ReactionsListForIssueCommentCmd) Run(isValueSetMap map[string]bool) err
 type ReactionsCreateForIssueCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue comment."`
@@ -155,7 +155,7 @@ func (c *ReactionsCreateForIssueCommentCmd) Run(isValueSetMap map[string]bool) e
 type ReactionsListForPullRequestReviewCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a pull request review comment."`
@@ -179,7 +179,7 @@ func (c *ReactionsListForPullRequestReviewCommentCmd) Run(isValueSetMap map[stri
 type ReactionsCreateForPullRequestReviewCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the pull request review comment."`

--- a/buildtool/generator/testdata/generated/reposcmd.go
+++ b/buildtool/generator/testdata/generated/reposcmd.go
@@ -287,7 +287,7 @@ func (c *ReposCreateInOrgCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -301,7 +301,7 @@ func (c *ReposGetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditCmd struct {
 	internal.BaseCmd
-	Owner            string `required:"" name:"owner"`
+	Owner            string `name:"owner"`
 	Repo             string `required:"" name:"repo"`
 	Name             string `required:"" name:"name" help:"The name of the repository."`
 	Description      string `name:"description" help:"A short description of the repository."`
@@ -340,7 +340,7 @@ func (c *ReposEditCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListTopicsCmd struct {
 	internal.BaseCmd
 	Mercy bool   "name:\"mercy-preview\" help:\"**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```\""
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -356,7 +356,7 @@ func (c *ReposListTopicsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposReplaceTopicsCmd struct {
 	internal.BaseCmd
 	Mercy bool     "name:\"mercy-preview\" help:\"**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```\""
-	Owner string   `required:"" name:"owner"`
+	Owner string   `name:"owner"`
 	Repo  string   `required:"" name:"repo"`
 	Names []string "required:\"\" name:\"names\" help:\"An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository.\""
 }
@@ -373,7 +373,7 @@ func (c *ReposReplaceTopicsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListContributorsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Anon    string "name:\"anon\" help:\"Set to `1` or `true` to include anonymous contributors in results.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -393,7 +393,7 @@ func (c *ReposListContributorsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListLanguagesCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -407,7 +407,7 @@ func (c *ReposListLanguagesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListTeamsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -425,7 +425,7 @@ func (c *ReposListTeamsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListTagsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -443,7 +443,7 @@ func (c *ReposListTagsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -458,7 +458,7 @@ func (c *ReposDeleteCmd) Run(isValueSetMap map[string]bool) error {
 type ReposTransferCmd struct {
 	internal.BaseCmd
 	Nightshade bool    "name:\"nightshade-preview\" required:\"\" help:\"**Note:** The [Repository Transfer API](/changes/2017-11-09-repository-transfer-api-preview) is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.nightshade-preview+json\n\n```\""
-	Owner      string  `required:"" name:"owner"`
+	Owner      string  `name:"owner"`
 	Repo       string  `required:"" name:"repo"`
 	NewOwner   string  `name:"new_owner" help:"**Required:** The username or organization name the repository will be transferred to."`
 	TeamIds    []int64 `name:"team_ids" help:"ID of the team or teams to add to the repository. Teams can only be added to organization-owned repositories."`
@@ -477,7 +477,7 @@ func (c *ReposTransferCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListBranchesCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Protected bool   "name:\"protected\" help:\"Setting to `true` returns only protected branches.\""
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -497,7 +497,7 @@ func (c *ReposListBranchesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetBranchCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -514,7 +514,7 @@ func (c *ReposGetBranchCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetBranchProtectionCmd struct {
 	internal.BaseCmd
 	LukeCage bool   "name:\"luke-cage-preview\" help:\"**Note:** The Protected Branches API now has a setting for requiring a specified number of approving pull request reviews before merging. This feature is currently available for developers to preview. See the [blog post](/changes/2018-03-16-protected-branches-required-approving-reviews) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.luke-cage-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Branch   string `required:"" name:"branch"`
 }
@@ -531,7 +531,7 @@ func (c *ReposGetBranchProtectionCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveBranchProtectionCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -547,7 +547,7 @@ func (c *ReposRemoveBranchProtectionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposGetProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -563,7 +563,7 @@ func (c *ReposGetProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap map[s
 
 type ReposUpdateProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Strict   bool     `name:"strict" help:"Require branches to be up to date before merging."`
@@ -583,7 +583,7 @@ func (c *ReposUpdateProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap ma
 
 type ReposRemoveProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -599,7 +599,7 @@ func (c *ReposRemoveProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap ma
 
 type ReposListProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -615,7 +615,7 @@ func (c *ReposListProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueSet
 
 type ReposReplaceProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -633,7 +633,7 @@ func (c *ReposReplaceProtectedBranchRequiredStatusChecksContextsCmd) Run(isValue
 
 type ReposAddProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -651,7 +651,7 @@ func (c *ReposAddProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueSetM
 
 type ReposRemoveProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -670,7 +670,7 @@ func (c *ReposRemoveProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueS
 type ReposGetProtectedBranchPullRequestReviewEnforcementCmd struct {
 	internal.BaseCmd
 	LukeCage bool   "name:\"luke-cage-preview\" help:\"**Note:** The Protected Branches API now has a setting for requiring a specified number of approving pull request reviews before merging. This feature is currently available for developers to preview. See the [blog post](/changes/2018-03-16-protected-branches-required-approving-reviews) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.luke-cage-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Branch   string `required:"" name:"branch"`
 }
@@ -687,7 +687,7 @@ func (c *ReposGetProtectedBranchPullRequestReviewEnforcementCmd) Run(isValueSetM
 
 type ReposRemoveProtectedBranchPullRequestReviewEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -704,7 +704,7 @@ func (c *ReposRemoveProtectedBranchPullRequestReviewEnforcementCmd) Run(isValueS
 type ReposGetProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -722,7 +722,7 @@ func (c *ReposGetProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[str
 type ReposAddProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -740,7 +740,7 @@ func (c *ReposAddProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[str
 type ReposRemoveProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -757,7 +757,7 @@ func (c *ReposRemoveProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[
 
 type ReposGetProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -773,7 +773,7 @@ func (c *ReposGetProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[strin
 
 type ReposAddProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -789,7 +789,7 @@ func (c *ReposAddProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[strin
 
 type ReposRemoveProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -805,7 +805,7 @@ func (c *ReposRemoveProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[st
 
 type ReposGetProtectedBranchRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -821,7 +821,7 @@ func (c *ReposGetProtectedBranchRestrictionsCmd) Run(isValueSetMap map[string]bo
 
 type ReposRemoveProtectedBranchRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -838,7 +838,7 @@ func (c *ReposRemoveProtectedBranchRestrictionsCmd) Run(isValueSetMap map[string
 type ReposListProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Branch  string `required:"" name:"branch"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -860,7 +860,7 @@ func (c *ReposListProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[stri
 type ReposReplaceProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -880,7 +880,7 @@ func (c *ReposReplaceProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[s
 type ReposAddProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -900,7 +900,7 @@ func (c *ReposAddProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[strin
 type ReposRemoveProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -919,7 +919,7 @@ func (c *ReposRemoveProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[st
 
 type ReposListProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -935,7 +935,7 @@ func (c *ReposListProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[stri
 
 type ReposReplaceProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -953,7 +953,7 @@ func (c *ReposReplaceProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[s
 
 type ReposAddProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -971,7 +971,7 @@ func (c *ReposAddProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[strin
 
 type ReposRemoveProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -990,7 +990,7 @@ func (c *ReposRemoveProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[st
 type ReposListCollaboratorsCmd struct {
 	internal.BaseCmd
 	Hellcat     bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Affiliation string "name:\"affiliation\" help:\"Filter collaborators returned by their affiliation. Can be one of:  \n\\* `outside`: All outside collaborators of an organization-owned repository.  \n\\* `direct`: All collaborators with permissions to an organization-owned repository, regardless of organization membership status.  \n\\* `all`: All collaborators the authenticated user can see.\""
 	PerPage     int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1012,7 +1012,7 @@ func (c *ReposListCollaboratorsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposCheckCollaboratorCmd struct {
 	internal.BaseCmd
 	Hellcat  bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1029,7 +1029,7 @@ func (c *ReposCheckCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCollaboratorPermissionLevelCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1045,7 +1045,7 @@ func (c *ReposGetCollaboratorPermissionLevelCmd) Run(isValueSetMap map[string]bo
 
 type ReposAddCollaboratorCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Username   string `required:"" name:"username"`
 	Permission string "name:\"permission\" help:\"The permission to grant the collaborator. **Only valid on organization-owned repositories.** Can be one of:  \n\\* `pull` - can pull, but not push to or administer this repository.  \n\\* `push` - can pull and push, but not administer this repository.  \n\\* `admin` - can pull, push and administer this repository.\""
@@ -1063,7 +1063,7 @@ func (c *ReposAddCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveCollaboratorCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1080,7 +1080,7 @@ func (c *ReposRemoveCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListCommitCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page         int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1100,7 +1100,7 @@ func (c *ReposListCommitCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListCommentsForCommitCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Ref          string `required:"" name:"ref"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1121,7 +1121,7 @@ func (c *ReposListCommentsForCommitCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposCreateCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Sha      string `required:"" name:"sha"`
 	Body     string `required:"" name:"body" help:"The contents of the comment."`
@@ -1146,7 +1146,7 @@ func (c *ReposCreateCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 }
@@ -1163,7 +1163,7 @@ func (c *ReposGetCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposUpdateCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The contents of the comment"`
@@ -1181,7 +1181,7 @@ func (c *ReposUpdateCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -1197,7 +1197,7 @@ func (c *ReposDeleteCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListCommitsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Sha     string `name:"sha" help:"SHA or branch to start listing commits from."`
 	Path    string `name:"path" help:"Only commits containing this file path will be returned."`
@@ -1225,7 +1225,7 @@ func (c *ReposListCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCommitCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Sha   string `required:"" name:"sha"`
 }
@@ -1241,7 +1241,7 @@ func (c *ReposGetCommitCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCommitRefShaCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -1257,7 +1257,7 @@ func (c *ReposGetCommitRefShaCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCompareCommitsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Base  string `required:"" name:"base"`
 	Head  string `required:"" name:"head"`
@@ -1275,7 +1275,7 @@ func (c *ReposCompareCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRetrieveCommunityProfileMetricsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1289,7 +1289,7 @@ func (c *ReposRetrieveCommunityProfileMetricsCmd) Run(isValueSetMap map[string]b
 
 type ReposGetReadmeCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `name:"ref" help:"The name of the commit/branch/tag."`
 }
@@ -1305,7 +1305,7 @@ func (c *ReposGetReadmeCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetContentsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Path  string `required:"" name:"path"`
 	Ref   string `name:"ref" help:"The name of the commit/branch/tag."`
@@ -1323,7 +1323,7 @@ func (c *ReposGetContentsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetArchiveLinkCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	ArchiveFormat string `required:"" name:"archive_format"`
 	Ref           string `required:"" name:"ref"`
@@ -1341,7 +1341,7 @@ func (c *ReposGetArchiveLinkCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListDeployKeysCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1359,7 +1359,7 @@ func (c *ReposListDeployKeysCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	KeyId int64  `required:"" name:"key_id"`
 }
@@ -1375,7 +1375,7 @@ func (c *ReposGetDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposAddDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Title    string `name:"title" help:"A name for the key."`
 	Key      string `required:"" name:"key" help:"The contents of the key."`
@@ -1395,7 +1395,7 @@ func (c *ReposAddDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	KeyId int64  `required:"" name:"key_id"`
 }
@@ -1412,7 +1412,7 @@ func (c *ReposRemoveDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListDeploymentsCmd struct {
 	internal.BaseCmd
 	AntMan      bool   "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Sha         string `name:"sha" help:"The SHA recorded at creation time."`
 	Ref         string `name:"ref" help:"The name of the ref. This can be a branch, tag, or SHA."`
@@ -1441,7 +1441,7 @@ type ReposGetDeploymentCmd struct {
 	internal.BaseCmd
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If a deployment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 }
@@ -1460,7 +1460,7 @@ func (c *ReposGetDeploymentCmd) Run(isValueSetMap map[string]bool) error {
 type ReposCreateDeploymentCmd struct {
 	internal.BaseCmd
 	AntMan                bool     "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner                 string   `required:"" name:"owner"`
+	Owner                 string   `name:"owner"`
 	Repo                  string   `required:"" name:"repo"`
 	Ref                   string   `required:"" name:"ref" help:"The ref to deploy. This can be a branch, tag, or SHA."`
 	Task                  string   "name:\"task\" help:\"Specifies a task to execute (e.g., `deploy` or `deploy:migrations`).\""
@@ -1495,7 +1495,7 @@ type ReposListDeploymentStatusesCmd struct {
 	internal.BaseCmd
 	Flash        bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1520,7 +1520,7 @@ type ReposGetDeploymentStatusCmd struct {
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If a deployment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	Flash        bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 	StatusId     int64  `required:"" name:"status_id"`
@@ -1543,7 +1543,7 @@ type ReposCreateDeploymentStatusCmd struct {
 	internal.BaseCmd
 	Flash          bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan         bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner          string `required:"" name:"owner"`
+	Owner          string `name:"owner"`
 	Repo           string `required:"" name:"repo"`
 	DeploymentId   int64  `required:"" name:"deployment_id"`
 	State          string "required:\"\" name:\"state\" help:\"The state of the status. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued` `pending`, or `success`. **Note:** To use the `inactive` state, you must provide the [`application/vnd.github.ant-man-preview+json`](https://developer.github.com/v3/previews/#enhanced-deployments) custom media type. To use the `in_progress` and `queued` states, you must provide the [`application/vnd.github.flash-preview+json`](https://developer.github.com/v3/previews/#deployment-statuses) custom media type.\""
@@ -1575,7 +1575,7 @@ func (c *ReposCreateDeploymentStatusCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposListDownloadsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1593,7 +1593,7 @@ func (c *ReposListDownloadsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetDownloadCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	DownloadId int64  `required:"" name:"download_id"`
 }
@@ -1609,7 +1609,7 @@ func (c *ReposGetDownloadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteDownloadCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	DownloadId int64  `required:"" name:"download_id"`
 }
@@ -1625,7 +1625,7 @@ func (c *ReposDeleteDownloadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListForksCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Sort    string "name:\"sort\" help:\"The sort order. Can be either `newest`, `oldest`, or `stargazers`.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1645,7 +1645,7 @@ func (c *ReposListForksCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateForkCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Organization string `name:"organization" help:"Optional parameter to specify the organization name if forking into an organization."`
 }
@@ -1661,7 +1661,7 @@ func (c *ReposCreateForkCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListInvitationsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1679,7 +1679,7 @@ func (c *ReposListInvitationsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteInvitationCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	InvitationId int64  `required:"" name:"invitation_id"`
 }
@@ -1695,7 +1695,7 @@ func (c *ReposDeleteInvitationCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposUpdateInvitationCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	InvitationId int64  `required:"" name:"invitation_id"`
 	Permissions  string "name:\"permissions\" help:\"The permissions that the associated user will have on the repository. Valid values are `read`, `write`, and `admin`.\""
@@ -1751,7 +1751,7 @@ func (c *ReposDeclineInvitationCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposMergeCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	Base          string `required:"" name:"base" help:"The name of the base branch that the head will be merged into."`
 	Head          string `required:"" name:"head" help:"The head to merge. This can be a branch name or a commit SHA1."`
@@ -1772,7 +1772,7 @@ func (c *ReposMergeCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetPagesCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"**Note:** The GitHub Pages API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 }
 
@@ -1788,7 +1788,7 @@ func (c *ReposGetPagesCmd) Run(isValueSetMap map[string]bool) error {
 type ReposUpdateInformationAboutPagesSiteCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"**Note:** The GitHub Pages API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	Cname           string "name:\"cname\" help:\"Specify a custom domain for the repository. Sending a `null` value will remove the custom domain. For more about custom domains, see '[Using a custom domain with GitHub Pages](https://help.github.com/articles/using-a-custom-domain-with-github-pages/).'\""
 	Source          string "name:\"source\" help:\"Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `'gh-pages'`, `'master'`, and `'master /docs'`.\""
@@ -1808,7 +1808,7 @@ func (c *ReposUpdateInformationAboutPagesSiteCmd) Run(isValueSetMap map[string]b
 type ReposRequestPageBuildCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"This endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice.\n\nTo access this endpoint during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 }
 
@@ -1823,7 +1823,7 @@ func (c *ReposRequestPageBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListPagesBuildsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1841,7 +1841,7 @@ func (c *ReposListPagesBuildsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetLatestPagesBuildCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1855,7 +1855,7 @@ func (c *ReposGetLatestPagesBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetPagesBuildCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	BuildId int64  `required:"" name:"build_id"`
 }
@@ -1871,7 +1871,7 @@ func (c *ReposGetPagesBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListReleasesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1889,7 +1889,7 @@ func (c *ReposListReleasesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 }
@@ -1905,7 +1905,7 @@ func (c *ReposGetReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetLatestReleaseCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1919,7 +1919,7 @@ func (c *ReposGetLatestReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetReleaseByTagCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Tag   string `required:"" name:"tag"`
 }
@@ -1935,7 +1935,7 @@ func (c *ReposGetReleaseByTagCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateReleaseCmd struct {
 	internal.BaseCmd
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	TagName         string `required:"" name:"tag_name" help:"The name of the tag."`
 	TargetCommitish string `name:"target_commitish" help:"Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists."`
@@ -1961,7 +1961,7 @@ func (c *ReposCreateReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditReleaseCmd struct {
 	internal.BaseCmd
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	ReleaseId       int64  `required:"" name:"release_id"`
 	TagName         string `name:"tag_name" help:"The name of the tag."`
@@ -1989,7 +1989,7 @@ func (c *ReposEditReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 }
@@ -2005,7 +2005,7 @@ func (c *ReposDeleteReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListAssetsForReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -2025,7 +2025,7 @@ func (c *ReposListAssetsForReleaseCmd) Run(isValueSetMap map[string]bool) error 
 
 type ReposGetReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 }
@@ -2041,7 +2041,7 @@ func (c *ReposGetReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 	Name    string `name:"name" help:"The file name of the asset."`
@@ -2061,7 +2061,7 @@ func (c *ReposEditReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 }
@@ -2077,7 +2077,7 @@ func (c *ReposDeleteReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetContributorsStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2091,7 +2091,7 @@ func (c *ReposGetContributorsStatsCmd) Run(isValueSetMap map[string]bool) error 
 
 type ReposGetCommitActivityStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2105,7 +2105,7 @@ func (c *ReposGetCommitActivityStatsCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposGetCodeFrequencyStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2119,7 +2119,7 @@ func (c *ReposGetCodeFrequencyStatsCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposGetParticipationStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2133,7 +2133,7 @@ func (c *ReposGetParticipationStatsCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposGetPunchCardStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2147,7 +2147,7 @@ func (c *ReposGetPunchCardStatsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateStatusCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Sha         string `required:"" name:"sha"`
 	State       string "required:\"\" name:\"state\" help:\"The state of the status. Can be one of `error`, `failure`, `pending`, or `success`.\""
@@ -2171,7 +2171,7 @@ func (c *ReposCreateStatusCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListStatusesForRefCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Ref     string `required:"" name:"ref"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -2191,7 +2191,7 @@ func (c *ReposListStatusesForRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCombinedStatusForRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -2207,7 +2207,7 @@ func (c *ReposGetCombinedStatusForRefCmd) Run(isValueSetMap map[string]bool) err
 
 type ReposGetTopReferrersCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2221,7 +2221,7 @@ func (c *ReposGetTopReferrersCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetTopPathsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2235,7 +2235,7 @@ func (c *ReposGetTopPathsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetViewsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Per   string "name:\"per\" help:\"Must be one of: `day`, `week`.\""
 }
@@ -2251,7 +2251,7 @@ func (c *ReposGetViewsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetClonesCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Per   string "name:\"per\" help:\"Must be one of: `day`, `week`.\""
 }
@@ -2267,7 +2267,7 @@ func (c *ReposGetClonesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListHooksCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -2285,7 +2285,7 @@ func (c *ReposListHooksCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2301,7 +2301,7 @@ func (c *ReposGetHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposTestPushHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2317,7 +2317,7 @@ func (c *ReposTestPushHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposPingHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2333,7 +2333,7 @@ func (c *ReposPingHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }

--- a/buildtool/generator/testdata/generated/teamscmd.go
+++ b/buildtool/generator/testdata/generated/teamscmd.go
@@ -178,7 +178,7 @@ type TeamsCheckManagesRepoCmd struct {
 	internal.BaseCmd
 	Hellcat bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
 	TeamId  int64  `required:"" name:"team_id"`
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 }
 
@@ -196,7 +196,7 @@ type TeamsAddOrUpdateRepoCmd struct {
 	internal.BaseCmd
 	Hellcat    bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
 	TeamId     int64  `required:"" name:"team_id"`
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Permission string "name:\"permission\" help:\"The permission to grant the team on this repository. Can be one of:  \n\\* `pull` - team members can pull, but not push to or administer this repository.  \n\\* `push` - team members can pull and push, but not administer this repository.  \n\\* `admin` - team members can pull, push and administer this repository.  \n  \nIf no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.  \n**Note**: If you pass the `hellcat-preview` media type, you can promote—but not demote—a `permission` attribute inherited through a parent team.\""
 }
@@ -215,7 +215,7 @@ func (c *TeamsAddOrUpdateRepoCmd) Run(isValueSetMap map[string]bool) error {
 type TeamsRemoveRepoCmd struct {
 	internal.BaseCmd
 	TeamId int64  `required:"" name:"team_id"`
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 }
 

--- a/internal/basecmd.go
+++ b/internal/basecmd.go
@@ -105,6 +105,7 @@ func (c *BaseCmd) UpdateURLQuery(paramName string, value interface{}) {
 }
 
 func (c *BaseCmd) newRequest(method string) (*http.Request, error) {
+	c.url.Path = strings.Replace(c.url.Path, "//", "/", -1)
 	u := strings.Join([]string{
 		strings.TrimSuffix(c.APIBaseURL, "/"),
 		strings.TrimPrefix(c.url.String(), "/"),

--- a/internal/generated/activitycmd.go
+++ b/internal/generated/activitycmd.go
@@ -57,7 +57,7 @@ func (c *ActivityListPublicEventsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListRepoEventsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -75,7 +75,7 @@ func (c *ActivityListRepoEventsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListPublicEventsForRepoNetworkCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -223,7 +223,7 @@ func (c *ActivityListNotificationsCmd) Run(isValueSetMap map[string]bool) error 
 
 type ActivityListNotificationsForRepoCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	All           bool   "name:\"all\" help:\"If `true`, show notifications marked as read.\""
 	Participating bool   "name:\"participating\" help:\"If `true`, only shows notifications in which the user is directly participating or mentioned.\""
@@ -261,7 +261,7 @@ func (c *ActivityMarkAsReadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityMarkNotificationsAsReadForRepoCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	LastReadAt string "name:\"last_read_at\" help:\"Describes the last point that notifications were checked. Anything updated since this time will not be updated. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.\""
 }
@@ -339,7 +339,7 @@ func (c *ActivityDeleteThreadSubscriptionCmd) Run(isValueSetMap map[string]bool)
 
 type ActivityListStargazersForRepoCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -395,7 +395,7 @@ func (c *ActivityListReposStarredByAuthenticatedUserCmd) Run(isValueSetMap map[s
 
 type ActivityCheckStarringRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -409,7 +409,7 @@ func (c *ActivityCheckStarringRepoCmd) Run(isValueSetMap map[string]bool) error 
 
 type ActivityStarRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -423,7 +423,7 @@ func (c *ActivityStarRepoCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityUnstarRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -437,7 +437,7 @@ func (c *ActivityUnstarRepoCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityListWatchersForRepoCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -485,7 +485,7 @@ func (c *ActivityListWatchedReposForAuthenticatedUserCmd) Run(isValueSetMap map[
 
 type ActivityGetRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -499,7 +499,7 @@ func (c *ActivityGetRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ActivitySetRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Subscribed bool   `name:"subscribed" help:"Determines if notifications should be received from this repository."`
 	Ignored    bool   `name:"ignored" help:"Determines if all notifications should be blocked from this repository."`
@@ -517,7 +517,7 @@ func (c *ActivitySetRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ActivityDeleteRepoSubscriptionCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -531,7 +531,7 @@ func (c *ActivityDeleteRepoSubscriptionCmd) Run(isValueSetMap map[string]bool) e
 
 type ActivityCheckWatchingRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -545,7 +545,7 @@ func (c *ActivityCheckWatchingRepoLegacyCmd) Run(isValueSetMap map[string]bool) 
 
 type ActivityWatchRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -559,7 +559,7 @@ func (c *ActivityWatchRepoLegacyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ActivityStopWatchingRepoLegacyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 

--- a/internal/generated/appscmd.go
+++ b/internal/generated/appscmd.go
@@ -130,7 +130,7 @@ func (c *AppsFindOrgInstallationCmd) Run(isValueSetMap map[string]bool) error {
 type AppsFindRepoInstallationCmd struct {
 	internal.BaseCmd
 	MachineMan bool   "name:\"machine-man-preview\" required:\"\" help:\"**Note:** To access the API with your GitHub App, you must provide a custom [media type](/v3/media) in the `Accept` Header for your requests.\n\n`application/vnd.github.machine-man-preview+json`\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 

--- a/internal/generated/checkscmd.go
+++ b/internal/generated/checkscmd.go
@@ -18,7 +18,7 @@ type ChecksCmd struct {
 type ChecksListForRefCmd struct {
 	internal.BaseCmd
 	Antiope   bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Ref       string `required:"" name:"ref"`
 	CheckName string "name:\"check_name\" help:\"Returns check runs with the specified `name`.\""
@@ -46,7 +46,7 @@ func (c *ChecksListForRefCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListForSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 	CheckName    string "name:\"check_name\" help:\"Returns check runs with the specified `name`.\""
@@ -74,7 +74,7 @@ func (c *ChecksListForSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksGetCmd struct {
 	internal.BaseCmd
 	Antiope    bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	CheckRunId int64  `required:"" name:"check_run_id"`
 }
@@ -92,7 +92,7 @@ func (c *ChecksGetCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListAnnotationsCmd struct {
 	internal.BaseCmd
 	Antiope    bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	CheckRunId int64  `required:"" name:"check_run_id"`
 	PerPage    int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -114,7 +114,7 @@ func (c *ChecksListAnnotationsCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksGetSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 }
@@ -132,7 +132,7 @@ func (c *ChecksGetSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksListSuitesForRefCmd struct {
 	internal.BaseCmd
 	Antiope   bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Ref       string `required:"" name:"ref"`
 	AppId     int64  "name:\"app_id\" help:\"Filters check suites by GitHub App `id`.\""
@@ -158,7 +158,7 @@ func (c *ChecksListSuitesForRefCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksCreateSuiteCmd struct {
 	internal.BaseCmd
 	Antiope bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	HeadSha string `required:"" name:"head_sha" help:"The sha of the head commit."`
 }
@@ -176,7 +176,7 @@ func (c *ChecksCreateSuiteCmd) Run(isValueSetMap map[string]bool) error {
 type ChecksRerequestSuiteCmd struct {
 	internal.BaseCmd
 	Antiope      bool   "name:\"antiope-preview\" required:\"\" help:\"The Checks API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2018-05-07-new-checks-api-public-beta/) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.antiope-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CheckSuiteId int64  `required:"" name:"check_suite_id"`
 }

--- a/internal/generated/codesofconductcmd.go
+++ b/internal/generated/codesofconductcmd.go
@@ -39,7 +39,7 @@ func (c *CodesOfConductGetConductCodeCmd) Run(isValueSetMap map[string]bool) err
 type CodesOfConductGetForRepoCmd struct {
 	internal.BaseCmd
 	ScarletWitch bool   "name:\"scarlet-witch-preview\" required:\"\" help:\"**Note:** The Codes of Conduct API is currently available for developers to preview.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.scarlet-witch-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 }
 

--- a/internal/generated/gitcmd.go
+++ b/internal/generated/gitcmd.go
@@ -19,7 +19,7 @@ type GitCmd struct {
 
 type GitGetBlobCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	FileSha string `required:"" name:"file_sha"`
 }
@@ -35,7 +35,7 @@ func (c *GitGetBlobCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitCreateBlobCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Content  string `required:"" name:"content" help:"The new blob's content."`
 	Encoding string "name:\"encoding\" help:\"The encoding used for `content`. Currently, `'utf-8'` and `'base64'` are supported.\""
@@ -53,7 +53,7 @@ func (c *GitCreateBlobCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetCommitCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommitSha string `required:"" name:"commit_sha"`
 }
@@ -69,7 +69,7 @@ func (c *GitGetCommitCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string "required:\"\" name:\"ref\" help:\"Must be formatted as `heads/branch`, not just `branch`\""
 }
@@ -85,7 +85,7 @@ func (c *GitGetRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitListRefsCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Namespace string "name:\"namespace\" help:\"Filter by sub-namespace (reference prefix). Most commen examples would be `'heads/'` and `'tags/'` to retrieve branches or tags\""
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -105,7 +105,7 @@ func (c *GitListRefsCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitCreateRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string "required:\"\" name:\"ref\" help:\"The name of the fully qualified reference (ie: `refs/heads/master`). If it doesn't start with 'refs' and have at least two slashes, it will be rejected.\""
 	Sha   string `required:"" name:"sha" help:"The SHA1 value for this reference."`
@@ -123,7 +123,7 @@ func (c *GitCreateRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitUpdateRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 	Sha   string `required:"" name:"sha" help:"The SHA1 value to set this reference to"`
@@ -143,7 +143,7 @@ func (c *GitUpdateRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitDeleteRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -159,7 +159,7 @@ func (c *GitDeleteRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetTagCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	TagSha string `required:"" name:"tag_sha"`
 }
@@ -175,7 +175,7 @@ func (c *GitGetTagCmd) Run(isValueSetMap map[string]bool) error {
 
 type GitGetTreeCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	TreeSha   string `required:"" name:"tree_sha"`
 	Recursive int64  `name:"recursive"`

--- a/internal/generated/issuescmd.go
+++ b/internal/generated/issuescmd.go
@@ -149,7 +149,7 @@ type IssuesListForRepoCmd struct {
 	Symmetra     bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue is opened via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Milestone    string "name:\"milestone\" help:\"If an `integer` is passed, it should refer to a milestone by its `number` field. If the string `*` is passed, issues with any milestone are accepted. If the string `none` is passed, issues without milestones are returned.\""
 	State        string "name:\"state\" help:\"Indicates the state of the issues to return. Can be either `open`, `closed`, or `all`.\""
@@ -190,7 +190,7 @@ type IssuesGetCmd struct {
 	internal.BaseCmd
 	Symmetra     bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 }
@@ -209,7 +209,7 @@ func (c *IssuesGetCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesCreateCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Title     string   `required:"" name:"title" help:"The title of the issue."`
 	Body      string   `name:"body" help:"The contents of the issue."`
@@ -237,7 +237,7 @@ func (c *IssuesCreateCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesEditCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Title     string   `name:"title" help:"The title of the issue."`
@@ -269,7 +269,7 @@ func (c *IssuesEditCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesLockCmd struct {
 	internal.BaseCmd
 	SailorV    bool   "name:\"sailor-v-preview\" help:\"**Note:** You can now add a reason when you lock an issue. This feature is currently available for developers to preview. See the [blog post](/changes/2018-01-10-lock-reason-api-preview) for full details. To access this feature, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.sailor-v-preview+json\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Number     int64  `required:"" name:"number"`
 	LockReason string "name:\"lock_reason\" help:\"The reason for locking the issue or pull request conversation. Lock will fail if you don't use one of these reasons:  \n\\* `off-topic`  \n\\* `too heated`  \n\\* `resolved`  \n\\* `spam`\""
@@ -288,7 +288,7 @@ func (c *IssuesLockCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesUnlockCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -304,7 +304,7 @@ func (c *IssuesUnlockCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesListAssigneesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -322,7 +322,7 @@ func (c *IssuesListAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCheckAssigneeCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Assignee string `required:"" name:"assignee"`
 }
@@ -339,7 +339,7 @@ func (c *IssuesCheckAssigneeCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesAddAssigneesCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Assignees []string `name:"assignees" help:"Usernames of people to assign this issue to. _NOTE: Only users with push access can add assignees to an issue. Assignees are silently ignored otherwise._"`
@@ -359,7 +359,7 @@ func (c *IssuesAddAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesRemoveAssigneesCmd struct {
 	internal.BaseCmd
 	Symmetra  bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string   `required:"" name:"owner"`
+	Owner     string   `name:"owner"`
 	Repo      string   `required:"" name:"repo"`
 	Number    int64    `required:"" name:"number"`
 	Assignees []string `name:"assignees" help:"Usernames of assignees to remove from an issue. _NOTE: Only users with push access can remove assignees from an issue. Assignees are silently ignored otherwise._"`
@@ -379,7 +379,7 @@ func (c *IssuesRemoveAssigneesCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Since        string "name:\"since\" help:\"Only comments updated at or after this time are returned. This is a timestamp in ISO 8601 format: `YYYY-MM-DDTHH:MM:SSZ`.\""
@@ -403,7 +403,7 @@ func (c *IssuesListCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListCommentsForRepoCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Sort         string "name:\"sort\" help:\"Either `created` or `updated`.\""
 	Direction    string "name:\"direction\" help:\"Either `asc` or `desc`. Ignored without the `sort` parameter.\""
@@ -426,7 +426,7 @@ type IssuesGetCommentCmd struct {
 	internal.BaseCmd
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue comment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the issue comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -448,7 +448,7 @@ func (c *IssuesGetCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCreateCommentCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 	Body   string `required:"" name:"body" help:"The contents of the comment."`
@@ -466,7 +466,7 @@ func (c *IssuesCreateCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesEditCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The contents of the comment."`
@@ -484,7 +484,7 @@ func (c *IssuesEditCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -501,7 +501,7 @@ func (c *IssuesDeleteCommentCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListEventsCmd struct {
 	internal.BaseCmd
 	Starfox bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -524,7 +524,7 @@ type IssuesListEventsForRepoCmd struct {
 	internal.BaseCmd
 	Starfox  bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page     int64  `name:"page" help:"Page number of the results to fetch."`
@@ -547,7 +547,7 @@ type IssuesGetEventCmd struct {
 	Starfox    bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
 	Symmetra   bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
 	MachineMan bool   "name:\"machine-man-preview\" help:\"**Note:** If an issue event is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	EventId    int64  `required:"" name:"event_id"`
 }
@@ -567,7 +567,7 @@ func (c *IssuesGetEventCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsForRepoCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page     int64  `name:"page" help:"Page number of the results to fetch."`
@@ -587,7 +587,7 @@ func (c *IssuesListLabelsForRepoCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesGetLabelCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Name     string `required:"" name:"name"`
 }
@@ -605,7 +605,7 @@ func (c *IssuesGetLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesCreateLabelCmd struct {
 	internal.BaseCmd
 	Symmetra    bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Name        string "required:\"\" name:\"name\" help:\"The name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png ':strawberry:'). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).\""
 	Color       string "required:\"\" name:\"color\" help:\"The [hexadecimal color code](http://www.color-hex.com/) for the label, without the leading `#`.\""
@@ -627,7 +627,7 @@ func (c *IssuesCreateLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesUpdateLabelCmd struct {
 	internal.BaseCmd
 	Symmetra    bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	CurrentName string `required:"" name:"current_name"`
 	Name        string "name:\"name\" help:\"The new name of the label. Emoji can be added to label names, using either native emoji or colon-style markup. For example, typing `:strawberry:` will render the emoji ![:strawberry:](https://a248.e.akamai.net/assets.github.com/images/icons/emoji/unicode/1f353.png ':strawberry:'). For a full list of available emoji and codes, see [emoji-cheat-sheet.com](http://emoji-cheat-sheet.com/).\""
@@ -650,7 +650,7 @@ func (c *IssuesUpdateLabelCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteLabelCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Name  string `required:"" name:"name"`
 }
@@ -667,7 +667,7 @@ func (c *IssuesDeleteLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsOnIssueCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -689,7 +689,7 @@ func (c *IssuesListLabelsOnIssueCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesAddLabelsCmd struct {
 	internal.BaseCmd
 	Symmetra bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Number   int64    `required:"" name:"number"`
 	Labels   []string "required:\"\" name:\"labels\" help:\"The name of the label to add to the issue. Must contain at least one label. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.\""
@@ -709,7 +709,7 @@ func (c *IssuesAddLabelsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesRemoveLabelCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	Name     string `required:"" name:"name"`
@@ -729,7 +729,7 @@ func (c *IssuesRemoveLabelCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesReplaceLabelsCmd struct {
 	internal.BaseCmd
 	Symmetra bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Number   int64    `required:"" name:"number"`
 	Labels   []string "name:\"labels\" help:\"The names of the labels to add to the issue. You can pass an empty array to remove all labels. **Note:** Alternatively, you can pass a single label as a `string` or an `array` of labels directly, but GitHub recommends passing an object with the `labels` key.\""
@@ -748,7 +748,7 @@ func (c *IssuesReplaceLabelsCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesRemoveLabelsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -765,7 +765,7 @@ func (c *IssuesRemoveLabelsCmd) Run(isValueSetMap map[string]bool) error {
 type IssuesListLabelsForMilestoneCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	PerPage  int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -786,7 +786,7 @@ func (c *IssuesListLabelsForMilestoneCmd) Run(isValueSetMap map[string]bool) err
 
 type IssuesListMilestonesForRepoCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	State     string "name:\"state\" help:\"The state of the milestone. Either `open`, `closed`, or `all`.\""
 	Sort      string "name:\"sort\" help:\"What to sort results by. Either `due_on` or `completeness`.\""
@@ -810,7 +810,7 @@ func (c *IssuesListMilestonesForRepoCmd) Run(isValueSetMap map[string]bool) erro
 
 type IssuesGetMilestoneCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -826,7 +826,7 @@ func (c *IssuesGetMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesCreateMilestoneCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Title       string `required:"" name:"title" help:"The title of the milestone."`
 	State       string "name:\"state\" help:\"The state of the milestone. Either `open` or `closed`.\""
@@ -848,7 +848,7 @@ func (c *IssuesCreateMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesUpdateMilestoneCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Number      int64  `required:"" name:"number"`
 	Title       string `name:"title" help:"The title of the milestone."`
@@ -872,7 +872,7 @@ func (c *IssuesUpdateMilestoneCmd) Run(isValueSetMap map[string]bool) error {
 
 type IssuesDeleteMilestoneCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -890,7 +890,7 @@ type IssuesListEventsForTimelineCmd struct {
 	internal.BaseCmd
 	Mockingbird bool   "name:\"mockingbird-preview\" required:\"\" help:\"The API to get issue timeline events is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-23-timeline-preview-api/) for full details. To access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mockingbird-preview\n\n```\""
 	Starfox     bool   "name:\"starfox-preview\" help:\"Project card details are now shown in REST API v3 responses for project-related issue and timeline events. This feature is now available for developers to preview. For details, see the [blog post](/changes/2018-09-05-project-card-events).\n\nTo receive the `project_card` attribute, project boards must be [enabled](https://help.github.com/articles/disabling-project-boards-in-a-repository) for a repository, and you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n application/vnd.github.starfox-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Number      int64  `required:"" name:"number"`
 	PerPage     int64  `name:"per_page" help:"Results per page (max 100)"`

--- a/internal/generated/licensescmd.go
+++ b/internal/generated/licensescmd.go
@@ -34,7 +34,7 @@ func (c *LicensesGetCmd) Run(isValueSetMap map[string]bool) error {
 
 type LicensesGetForRepoCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 

--- a/internal/generated/migrationscmd.go
+++ b/internal/generated/migrationscmd.go
@@ -132,7 +132,7 @@ func (c *MigrationsUnlockRepoForOrgCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsStartImportCmd struct {
 	internal.BaseCmd
 	BarredRock  bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	VcsUrl      string `required:"" name:"vcs_url" help:"The URL of the originating repository."`
 	Vcs         string "name:\"vcs\" help:\"The originating VCS type. Can be one of `subversion`, `git`, `mercurial`, or `tfvc`. Please be aware that without this parameter, the import job will take additional time to detect the VCS type before beginning the import. This detection step will be reflected in the response.\""
@@ -158,7 +158,7 @@ func (c *MigrationsStartImportCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsGetImportProgressCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 
@@ -174,7 +174,7 @@ func (c *MigrationsGetImportProgressCmd) Run(isValueSetMap map[string]bool) erro
 type MigrationsUpdateImportCmd struct {
 	internal.BaseCmd
 	BarredRock  bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	VcsUsername string `name:"vcs_username" help:"The username to provide to the originating repository."`
 	VcsPassword string `name:"vcs_password" help:"The password to provide to the originating repository."`
@@ -194,7 +194,7 @@ func (c *MigrationsUpdateImportCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsGetCommitAuthorsCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Since      string "name:\"since\" help:\"Only authors found after this id are returned. Provide the highest author ID you've seen so far. New authors may be added to the list at any point while the importer is performing the `raw` step.\""
 }
@@ -212,7 +212,7 @@ func (c *MigrationsGetCommitAuthorsCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsMapCommitAuthorCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	AuthorId   int64  `required:"" name:"author_id"`
 	Email      string `name:"email" help:"The new Git author email."`
@@ -234,7 +234,7 @@ func (c *MigrationsMapCommitAuthorCmd) Run(isValueSetMap map[string]bool) error 
 type MigrationsSetLfsPreferenceCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	UseLfs     string "required:\"\" name:\"use_lfs\" help:\"Can be one of `opt_in` (large files will be stored using Git LFS) or `opt_out` (large files will be removed during the import).\""
 }
@@ -252,7 +252,7 @@ func (c *MigrationsSetLfsPreferenceCmd) Run(isValueSetMap map[string]bool) error
 type MigrationsGetLargeFilesCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 
@@ -268,7 +268,7 @@ func (c *MigrationsGetLargeFilesCmd) Run(isValueSetMap map[string]bool) error {
 type MigrationsCancelImportCmd struct {
 	internal.BaseCmd
 	BarredRock bool   "name:\"barred-rock-preview\" required:\"\" help:\"The source import APIs are currently in public preview. See the [source import](/v3/previews/#source-import) preview for more details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.barred-rock-preview\n\n```\""
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 }
 

--- a/internal/generated/projectscmd.go
+++ b/internal/generated/projectscmd.go
@@ -33,7 +33,7 @@ type ProjectsCmd struct {
 type ProjectsListForRepoCmd struct {
 	internal.BaseCmd
 	Inertia bool   "name:\"inertia-preview\" required:\"\" help:\"The Projects API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-10-27-changes-to-projects-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.inertia-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	State   string "name:\"state\" help:\"Indicates the state of the projects to return. Can be either `open`, `closed`, or `all`.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -93,7 +93,7 @@ func (c *ProjectsGetCmd) Run(isValueSetMap map[string]bool) error {
 type ProjectsCreateForRepoCmd struct {
 	internal.BaseCmd
 	Inertia bool   "name:\"inertia-preview\" required:\"\" help:\"The Projects API is currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-10-27-changes-to-projects-api) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.inertia-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Name    string `required:"" name:"name" help:"The name of the project."`
 	Body    string `name:"body" help:"The body of the project."`

--- a/internal/generated/pullscmd.go
+++ b/internal/generated/pullscmd.go
@@ -35,7 +35,7 @@ type PullsCmd struct {
 type PullsListCmd struct {
 	internal.BaseCmd
 	Symmetra  bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	State     string "name:\"state\" help:\"Either `open`, `closed`, or `all` to filter by state.\""
 	Head      string "name:\"head\" help:\"Filter pulls by head user and branch name in the format of `user:ref-name`. Example: `github:new-script-format`.\""
@@ -65,7 +65,7 @@ func (c *PullsListCmd) Run(isValueSetMap map[string]bool) error {
 type PullsGetCmd struct {
 	internal.BaseCmd
 	Symmetra bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 }
@@ -83,7 +83,7 @@ func (c *PullsGetCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Title               string `required:"" name:"title" help:"The title of the pull request."`
 	Head                string "required:\"\" name:\"head\" help:\"The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.\""
@@ -109,7 +109,7 @@ func (c *PullsCreateCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateFromIssueCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Issue               int64  `required:"" name:"issue" help:"The issue number in this repository to turn into a Pull Request."`
 	Head                string "required:\"\" name:\"head\" help:\"The name of the branch where your changes are implemented. For cross-repository pull requests in the same network, namespace `head` with a user like this: `username:branch`.\""
@@ -133,7 +133,7 @@ func (c *PullsCreateFromIssueCmd) Run(isValueSetMap map[string]bool) error {
 type PullsUpdateCmd struct {
 	internal.BaseCmd
 	Symmetra            bool   "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner               string `required:"" name:"owner"`
+	Owner               string `name:"owner"`
 	Repo                string `required:"" name:"repo"`
 	Number              int64  `required:"" name:"number"`
 	Title               string `name:"title" help:"The title of the pull request."`
@@ -160,7 +160,7 @@ func (c *PullsUpdateCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListCommitsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -180,7 +180,7 @@ func (c *PullsListCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListFilesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -200,7 +200,7 @@ func (c *PullsListFilesCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCheckIfMergedCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Number int64  `required:"" name:"number"`
 }
@@ -216,7 +216,7 @@ func (c *PullsCheckIfMergedCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsMergeCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	Number        int64  `required:"" name:"number"`
 	CommitTitle   string `name:"commit_title" help:"Title for the automatic commit message."`
@@ -240,7 +240,7 @@ func (c *PullsMergeCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListReviewsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -260,7 +260,7 @@ func (c *PullsListReviewsCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsGetReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -278,7 +278,7 @@ func (c *PullsGetReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeletePendingReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -296,7 +296,7 @@ func (c *PullsDeletePendingReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsGetCommentsForReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -318,7 +318,7 @@ func (c *PullsGetCommentsForReviewCmd) Run(isValueSetMap map[string]bool) error 
 
 type PullsSubmitReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -340,7 +340,7 @@ func (c *PullsSubmitReviewCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDismissReviewCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	ReviewId int64  `required:"" name:"review_id"`
@@ -361,7 +361,7 @@ func (c *PullsDismissReviewCmd) Run(isValueSetMap map[string]bool) error {
 type PullsListCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Sort         string "name:\"sort\" help:\"Can be either `created` or `updated` comments.\""
@@ -389,7 +389,7 @@ func (c *PullsListCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type PullsListCommentsForRepoCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Sort         string "name:\"sort\" help:\"Can be either `created` or `updated` comments.\""
 	Direction    string "name:\"direction\" help:\"Can be either `asc` or `desc`. Ignored without `sort` parameter.\""
@@ -415,7 +415,7 @@ func (c *PullsListCommentsForRepoCmd) Run(isValueSetMap map[string]bool) error {
 type PullsGetCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the review comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 }
@@ -432,7 +432,7 @@ func (c *PullsGetCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCreateCommentCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Number   int64  `required:"" name:"number"`
 	Body     string `required:"" name:"body" help:"The text of the comment."`
@@ -456,7 +456,7 @@ func (c *PullsCreateCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsCreateCommentReplyCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Number    int64  `required:"" name:"number"`
 	Body      string `required:"" name:"body" help:"The text of the comment."`
@@ -476,7 +476,7 @@ func (c *PullsCreateCommentReplyCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsEditCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The text of the comment."`
@@ -494,7 +494,7 @@ func (c *PullsEditCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeleteCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -510,7 +510,7 @@ func (c *PullsDeleteCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsListReviewRequestsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Number  int64  `required:"" name:"number"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -531,7 +531,7 @@ func (c *PullsListReviewRequestsCmd) Run(isValueSetMap map[string]bool) error {
 type PullsCreateReviewRequestCmd struct {
 	internal.BaseCmd
 	Symmetra      bool     "name:\"symmetra-preview\" help:\"**Note:** You can now use emoji in label names, add descriptions to labels, and search for labels in a repository. See the [blog post](/changes/2018-02-22-label-description-search-preview) for full details. To access these features and receive payloads with this data during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.symmetra-preview+json\n\n```\""
-	Owner         string   `required:"" name:"owner"`
+	Owner         string   `name:"owner"`
 	Repo          string   `required:"" name:"repo"`
 	Number        int64    `required:"" name:"number"`
 	Reviewers     []string "name:\"reviewers\" help:\"An array of user `login`s that will be requested.\""
@@ -552,7 +552,7 @@ func (c *PullsCreateReviewRequestCmd) Run(isValueSetMap map[string]bool) error {
 
 type PullsDeleteReviewRequestCmd struct {
 	internal.BaseCmd
-	Owner         string   `required:"" name:"owner"`
+	Owner         string   `name:"owner"`
 	Repo          string   `required:"" name:"repo"`
 	Number        int64    `required:"" name:"number"`
 	Reviewers     []string "name:\"reviewers\" help:\"An array of user `login`s that will be removed.\""

--- a/internal/generated/reactionscmd.go
+++ b/internal/generated/reactionscmd.go
@@ -23,7 +23,7 @@ type ReactionsCmd struct {
 type ReactionsListForCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a commit comment."`
@@ -47,7 +47,7 @@ func (c *ReactionsListForCommitCommentCmd) Run(isValueSetMap map[string]bool) er
 type ReactionsCreateForCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the commit comment."`
@@ -67,7 +67,7 @@ func (c *ReactionsCreateForCommitCommentCmd) Run(isValueSetMap map[string]bool) 
 type ReactionsListForIssueCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue."`
@@ -91,7 +91,7 @@ func (c *ReactionsListForIssueCmd) Run(isValueSetMap map[string]bool) error {
 type ReactionsCreateForIssueCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Number       int64  `required:"" name:"number"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue."`
@@ -111,7 +111,7 @@ func (c *ReactionsCreateForIssueCmd) Run(isValueSetMap map[string]bool) error {
 type ReactionsListForIssueCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to an issue comment."`
@@ -135,7 +135,7 @@ func (c *ReactionsListForIssueCommentCmd) Run(isValueSetMap map[string]bool) err
 type ReactionsCreateForIssueCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the issue comment."`
@@ -155,7 +155,7 @@ func (c *ReactionsCreateForIssueCommentCmd) Run(isValueSetMap map[string]bool) e
 type ReactionsListForPullRequestReviewCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `name:"content" help:"Returns a single [reaction type](https://developer.github.com/v3/reactions/#reaction-types). Omit this parameter to list all reactions to a pull request review comment."`
@@ -179,7 +179,7 @@ func (c *ReactionsListForPullRequestReviewCommentCmd) Run(isValueSetMap map[stri
 type ReactionsCreateForPullRequestReviewCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" required:\"\" help:\"**Note:** APIs for managing reactions are currently available for developers to preview. See the [blog post](/changes/2016-05-12-reactions-api-preview) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 	Content      string `required:"" name:"content" help:"The [reaction type](https://developer.github.com/v3/reactions/#reaction-types) to add to the pull request review comment."`

--- a/internal/generated/reposcmd.go
+++ b/internal/generated/reposcmd.go
@@ -287,7 +287,7 @@ func (c *ReposCreateInOrgCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -301,7 +301,7 @@ func (c *ReposGetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditCmd struct {
 	internal.BaseCmd
-	Owner            string `required:"" name:"owner"`
+	Owner            string `name:"owner"`
 	Repo             string `required:"" name:"repo"`
 	Name             string `required:"" name:"name" help:"The name of the repository."`
 	Description      string `name:"description" help:"A short description of the repository."`
@@ -340,7 +340,7 @@ func (c *ReposEditCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListTopicsCmd struct {
 	internal.BaseCmd
 	Mercy bool   "name:\"mercy-preview\" help:\"**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```\""
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -356,7 +356,7 @@ func (c *ReposListTopicsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposReplaceTopicsCmd struct {
 	internal.BaseCmd
 	Mercy bool     "name:\"mercy-preview\" help:\"**Note:** The `topics` property for repositories on GitHub is currently available for developers to preview. To view the `topics` property in calls that return repository results, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mercy-preview+json\n\n```\""
-	Owner string   `required:"" name:"owner"`
+	Owner string   `name:"owner"`
 	Repo  string   `required:"" name:"repo"`
 	Names []string "required:\"\" name:\"names\" help:\"An array of topics to add to the repository. Pass one or more topics to _replace_ the set of existing topics. Send an empty array (`[]`) to clear all topics from the repository.\""
 }
@@ -373,7 +373,7 @@ func (c *ReposReplaceTopicsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListContributorsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Anon    string "name:\"anon\" help:\"Set to `1` or `true` to include anonymous contributors in results.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -393,7 +393,7 @@ func (c *ReposListContributorsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListLanguagesCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -407,7 +407,7 @@ func (c *ReposListLanguagesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListTeamsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -425,7 +425,7 @@ func (c *ReposListTeamsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListTagsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -443,7 +443,7 @@ func (c *ReposListTagsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -458,7 +458,7 @@ func (c *ReposDeleteCmd) Run(isValueSetMap map[string]bool) error {
 type ReposTransferCmd struct {
 	internal.BaseCmd
 	Nightshade bool    "name:\"nightshade-preview\" required:\"\" help:\"**Note:** The [Repository Transfer API](/changes/2017-11-09-repository-transfer-api-preview) is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.nightshade-preview+json\n\n```\""
-	Owner      string  `required:"" name:"owner"`
+	Owner      string  `name:"owner"`
 	Repo       string  `required:"" name:"repo"`
 	NewOwner   string  `name:"new_owner" help:"**Required:** The username or organization name the repository will be transferred to."`
 	TeamIds    []int64 `name:"team_ids" help:"ID of the team or teams to add to the repository. Teams can only be added to organization-owned repositories."`
@@ -477,7 +477,7 @@ func (c *ReposTransferCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListBranchesCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	Protected bool   "name:\"protected\" help:\"Setting to `true` returns only protected branches.\""
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -497,7 +497,7 @@ func (c *ReposListBranchesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetBranchCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -514,7 +514,7 @@ func (c *ReposGetBranchCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetBranchProtectionCmd struct {
 	internal.BaseCmd
 	LukeCage bool   "name:\"luke-cage-preview\" help:\"**Note:** The Protected Branches API now has a setting for requiring a specified number of approving pull request reviews before merging. This feature is currently available for developers to preview. See the [blog post](/changes/2018-03-16-protected-branches-required-approving-reviews) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.luke-cage-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Branch   string `required:"" name:"branch"`
 }
@@ -531,7 +531,7 @@ func (c *ReposGetBranchProtectionCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveBranchProtectionCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -547,7 +547,7 @@ func (c *ReposRemoveBranchProtectionCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposGetProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -563,7 +563,7 @@ func (c *ReposGetProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap map[s
 
 type ReposUpdateProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Strict   bool     `name:"strict" help:"Require branches to be up to date before merging."`
@@ -583,7 +583,7 @@ func (c *ReposUpdateProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap ma
 
 type ReposRemoveProtectedBranchRequiredStatusChecksCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -599,7 +599,7 @@ func (c *ReposRemoveProtectedBranchRequiredStatusChecksCmd) Run(isValueSetMap ma
 
 type ReposListProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -615,7 +615,7 @@ func (c *ReposListProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueSet
 
 type ReposReplaceProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -633,7 +633,7 @@ func (c *ReposReplaceProtectedBranchRequiredStatusChecksContextsCmd) Run(isValue
 
 type ReposAddProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -651,7 +651,7 @@ func (c *ReposAddProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueSetM
 
 type ReposRemoveProtectedBranchRequiredStatusChecksContextsCmd struct {
 	internal.BaseCmd
-	Owner    string   `required:"" name:"owner"`
+	Owner    string   `name:"owner"`
 	Repo     string   `required:"" name:"repo"`
 	Branch   string   `required:"" name:"branch"`
 	Contexts []string `required:"" name:"contexts"`
@@ -670,7 +670,7 @@ func (c *ReposRemoveProtectedBranchRequiredStatusChecksContextsCmd) Run(isValueS
 type ReposGetProtectedBranchPullRequestReviewEnforcementCmd struct {
 	internal.BaseCmd
 	LukeCage bool   "name:\"luke-cage-preview\" help:\"**Note:** The Protected Branches API now has a setting for requiring a specified number of approving pull request reviews before merging. This feature is currently available for developers to preview. See the [blog post](/changes/2018-03-16-protected-branches-required-approving-reviews) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.luke-cage-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Branch   string `required:"" name:"branch"`
 }
@@ -687,7 +687,7 @@ func (c *ReposGetProtectedBranchPullRequestReviewEnforcementCmd) Run(isValueSetM
 
 type ReposRemoveProtectedBranchPullRequestReviewEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -704,7 +704,7 @@ func (c *ReposRemoveProtectedBranchPullRequestReviewEnforcementCmd) Run(isValueS
 type ReposGetProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -722,7 +722,7 @@ func (c *ReposGetProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[str
 type ReposAddProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -740,7 +740,7 @@ func (c *ReposAddProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[str
 type ReposRemoveProtectedBranchRequiredSignaturesCmd struct {
 	internal.BaseCmd
 	Zzzax  bool   "name:\"zzzax-preview\" required:\"\" help:\"**Note:** Protected Branches API can now manage a setting for requiring signed commits. This feature is currently available for developers to preview. See the [blog post](/changes/2018-02-22-protected-branches-required-signatures) for full details. To access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.zzzax-preview+json\n\n```\""
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -757,7 +757,7 @@ func (c *ReposRemoveProtectedBranchRequiredSignaturesCmd) Run(isValueSetMap map[
 
 type ReposGetProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -773,7 +773,7 @@ func (c *ReposGetProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[strin
 
 type ReposAddProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -789,7 +789,7 @@ func (c *ReposAddProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[strin
 
 type ReposRemoveProtectedBranchAdminEnforcementCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -805,7 +805,7 @@ func (c *ReposRemoveProtectedBranchAdminEnforcementCmd) Run(isValueSetMap map[st
 
 type ReposGetProtectedBranchRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -821,7 +821,7 @@ func (c *ReposGetProtectedBranchRestrictionsCmd) Run(isValueSetMap map[string]bo
 
 type ReposRemoveProtectedBranchRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -838,7 +838,7 @@ func (c *ReposRemoveProtectedBranchRestrictionsCmd) Run(isValueSetMap map[string
 type ReposListProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Branch  string `required:"" name:"branch"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -860,7 +860,7 @@ func (c *ReposListProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[stri
 type ReposReplaceProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -880,7 +880,7 @@ func (c *ReposReplaceProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[s
 type ReposAddProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -900,7 +900,7 @@ func (c *ReposAddProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[strin
 type ReposRemoveProtectedBranchTeamRestrictionsCmd struct {
 	internal.BaseCmd
 	Hellcat bool     "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner   string   `required:"" name:"owner"`
+	Owner   string   `name:"owner"`
 	Repo    string   `required:"" name:"repo"`
 	Branch  string   `required:"" name:"branch"`
 	Teams   []string `required:"" name:"teams"`
@@ -919,7 +919,7 @@ func (c *ReposRemoveProtectedBranchTeamRestrictionsCmd) Run(isValueSetMap map[st
 
 type ReposListProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	Branch string `required:"" name:"branch"`
 }
@@ -935,7 +935,7 @@ func (c *ReposListProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[stri
 
 type ReposReplaceProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -953,7 +953,7 @@ func (c *ReposReplaceProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[s
 
 type ReposAddProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -971,7 +971,7 @@ func (c *ReposAddProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[strin
 
 type ReposRemoveProtectedBranchUserRestrictionsCmd struct {
 	internal.BaseCmd
-	Owner  string   `required:"" name:"owner"`
+	Owner  string   `name:"owner"`
 	Repo   string   `required:"" name:"repo"`
 	Branch string   `required:"" name:"branch"`
 	Users  []string `required:"" name:"users"`
@@ -990,7 +990,7 @@ func (c *ReposRemoveProtectedBranchUserRestrictionsCmd) Run(isValueSetMap map[st
 type ReposListCollaboratorsCmd struct {
 	internal.BaseCmd
 	Hellcat     bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Affiliation string "name:\"affiliation\" help:\"Filter collaborators returned by their affiliation. Can be one of:  \n\\* `outside`: All outside collaborators of an organization-owned repository.  \n\\* `direct`: All collaborators with permissions to an organization-owned repository, regardless of organization membership status.  \n\\* `all`: All collaborators the authenticated user can see.\""
 	PerPage     int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1012,7 +1012,7 @@ func (c *ReposListCollaboratorsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposCheckCollaboratorCmd struct {
 	internal.BaseCmd
 	Hellcat  bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1029,7 +1029,7 @@ func (c *ReposCheckCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCollaboratorPermissionLevelCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1045,7 +1045,7 @@ func (c *ReposGetCollaboratorPermissionLevelCmd) Run(isValueSetMap map[string]bo
 
 type ReposAddCollaboratorCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Username   string `required:"" name:"username"`
 	Permission string "name:\"permission\" help:\"The permission to grant the collaborator. **Only valid on organization-owned repositories.** Can be one of:  \n\\* `pull` - can pull, but not push to or administer this repository.  \n\\* `push` - can pull and push, but not administer this repository.  \n\\* `admin` - can pull, push and administer this repository.\""
@@ -1063,7 +1063,7 @@ func (c *ReposAddCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveCollaboratorCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Username string `required:"" name:"username"`
 }
@@ -1080,7 +1080,7 @@ func (c *ReposRemoveCollaboratorCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListCommitCommentsCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page         int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1100,7 +1100,7 @@ func (c *ReposListCommitCommentsCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListCommentsForCommitCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Ref          string `required:"" name:"ref"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1121,7 +1121,7 @@ func (c *ReposListCommentsForCommitCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposCreateCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Sha      string `required:"" name:"sha"`
 	Body     string `required:"" name:"body" help:"The contents of the comment."`
@@ -1146,7 +1146,7 @@ func (c *ReposCreateCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetCommitCommentCmd struct {
 	internal.BaseCmd
 	SquirrelGirl bool   "name:\"squirrel-girl-preview\" help:\"An additional `reactions` object in the commit comment payload is currently available for developers to preview. During the preview period, the APIs may change without advance notice. Please see the [blog post](/changes/2016-05-12-reactions-api-preview) for full details.\n\nTo access the API you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.squirrel-girl-preview\n\n```\n\nThe `reactions` key will have the following payload where `url` can be used to construct the API location for [listing and creating](/v3/reactions) reactions.\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	CommentId    int64  `required:"" name:"comment_id"`
 }
@@ -1163,7 +1163,7 @@ func (c *ReposGetCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposUpdateCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 	Body      string `required:"" name:"body" help:"The contents of the comment"`
@@ -1181,7 +1181,7 @@ func (c *ReposUpdateCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteCommitCommentCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	CommentId int64  `required:"" name:"comment_id"`
 }
@@ -1197,7 +1197,7 @@ func (c *ReposDeleteCommitCommentCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListCommitsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Sha     string `name:"sha" help:"SHA or branch to start listing commits from."`
 	Path    string `name:"path" help:"Only commits containing this file path will be returned."`
@@ -1225,7 +1225,7 @@ func (c *ReposListCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCommitCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Sha   string `required:"" name:"sha"`
 }
@@ -1241,7 +1241,7 @@ func (c *ReposGetCommitCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCommitRefShaCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -1257,7 +1257,7 @@ func (c *ReposGetCommitRefShaCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCompareCommitsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Base  string `required:"" name:"base"`
 	Head  string `required:"" name:"head"`
@@ -1275,7 +1275,7 @@ func (c *ReposCompareCommitsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRetrieveCommunityProfileMetricsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1289,7 +1289,7 @@ func (c *ReposRetrieveCommunityProfileMetricsCmd) Run(isValueSetMap map[string]b
 
 type ReposGetReadmeCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `name:"ref" help:"The name of the commit/branch/tag."`
 }
@@ -1305,7 +1305,7 @@ func (c *ReposGetReadmeCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetContentsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Path  string `required:"" name:"path"`
 	Ref   string `name:"ref" help:"The name of the commit/branch/tag."`
@@ -1323,7 +1323,7 @@ func (c *ReposGetContentsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetArchiveLinkCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	ArchiveFormat string `required:"" name:"archive_format"`
 	Ref           string `required:"" name:"ref"`
@@ -1341,7 +1341,7 @@ func (c *ReposGetArchiveLinkCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListDeployKeysCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1359,7 +1359,7 @@ func (c *ReposListDeployKeysCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	KeyId int64  `required:"" name:"key_id"`
 }
@@ -1375,7 +1375,7 @@ func (c *ReposGetDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposAddDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner    string `required:"" name:"owner"`
+	Owner    string `name:"owner"`
 	Repo     string `required:"" name:"repo"`
 	Title    string `name:"title" help:"A name for the key."`
 	Key      string `required:"" name:"key" help:"The contents of the key."`
@@ -1395,7 +1395,7 @@ func (c *ReposAddDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposRemoveDeployKeyCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	KeyId int64  `required:"" name:"key_id"`
 }
@@ -1412,7 +1412,7 @@ func (c *ReposRemoveDeployKeyCmd) Run(isValueSetMap map[string]bool) error {
 type ReposListDeploymentsCmd struct {
 	internal.BaseCmd
 	AntMan      bool   "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Sha         string `name:"sha" help:"The SHA recorded at creation time."`
 	Ref         string `name:"ref" help:"The name of the ref. This can be a branch, tag, or SHA."`
@@ -1441,7 +1441,7 @@ type ReposGetDeploymentCmd struct {
 	internal.BaseCmd
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If a deployment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 }
@@ -1460,7 +1460,7 @@ func (c *ReposGetDeploymentCmd) Run(isValueSetMap map[string]bool) error {
 type ReposCreateDeploymentCmd struct {
 	internal.BaseCmd
 	AntMan                bool     "name:\"ant-man-preview\" help:\"**Note:** The `transient_environment` and `production_environment` parameters are currently available for developers to preview. During the preview period, the API may change without advance notice. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner                 string   `required:"" name:"owner"`
+	Owner                 string   `name:"owner"`
 	Repo                  string   `required:"" name:"repo"`
 	Ref                   string   `required:"" name:"ref" help:"The ref to deploy. This can be a branch, tag, or SHA."`
 	Task                  string   "name:\"task\" help:\"Specifies a task to execute (e.g., `deploy` or `deploy:migrations`).\""
@@ -1495,7 +1495,7 @@ type ReposListDeploymentStatusesCmd struct {
 	internal.BaseCmd
 	Flash        bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 	PerPage      int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1520,7 +1520,7 @@ type ReposGetDeploymentStatusCmd struct {
 	MachineMan   bool   "name:\"machine-man-preview\" help:\"**Note:** If a deployment is created via a GitHub App, the response will include the `performed_via_github_app` object with information about the GitHub App. For more information, see the [related blog post](/changes/2016-09-14-Integrations-Early-Access).\n\nTo receive the `performed_via_github_app` object is the response, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.machine-man-preview\n\n```\""
 	Flash        bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan       bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	DeploymentId int64  `required:"" name:"deployment_id"`
 	StatusId     int64  `required:"" name:"status_id"`
@@ -1543,7 +1543,7 @@ type ReposCreateDeploymentStatusCmd struct {
 	internal.BaseCmd
 	Flash          bool   "name:\"flash-preview\" help:\"**Note:** New features in the Deployments API on GitHub are currently available during a public beta. Please see the [blog post](/changes/2018-10-16-deployments-environments-states-and-auto-inactive-updates/) for full details.\n\nTo access the new `environment` parameter, the two new values for the `state` parameter (`in_progress` and `queued`), and use `auto_inactive` on production deployments during the public beta period, you must provide the following custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.flash-preview+json\n\n```\""
 	AntMan         bool   "name:\"ant-man-preview\" help:\"**Note:** The `inactive` state and the `log_url`, `environment_url`, and `auto_inactive` parameters are currently available for developers to preview. Please see the [blog post](/changes/2016-04-06-deployment-and-deployment-status-enhancements) for full details.\n\nTo access the API during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.ant-man-preview+json\n\n```\""
-	Owner          string `required:"" name:"owner"`
+	Owner          string `name:"owner"`
 	Repo           string `required:"" name:"repo"`
 	DeploymentId   int64  `required:"" name:"deployment_id"`
 	State          string "required:\"\" name:\"state\" help:\"The state of the status. Can be one of `error`, `failure`, `inactive`, `in_progress`, `queued` `pending`, or `success`. **Note:** To use the `inactive` state, you must provide the [`application/vnd.github.ant-man-preview+json`](https://developer.github.com/v3/previews/#enhanced-deployments) custom media type. To use the `in_progress` and `queued` states, you must provide the [`application/vnd.github.flash-preview+json`](https://developer.github.com/v3/previews/#deployment-statuses) custom media type.\""
@@ -1575,7 +1575,7 @@ func (c *ReposCreateDeploymentStatusCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposListDownloadsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1593,7 +1593,7 @@ func (c *ReposListDownloadsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetDownloadCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	DownloadId int64  `required:"" name:"download_id"`
 }
@@ -1609,7 +1609,7 @@ func (c *ReposGetDownloadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteDownloadCmd struct {
 	internal.BaseCmd
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	DownloadId int64  `required:"" name:"download_id"`
 }
@@ -1625,7 +1625,7 @@ func (c *ReposDeleteDownloadCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListForksCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Sort    string "name:\"sort\" help:\"The sort order. Can be either `newest`, `oldest`, or `stargazers`.\""
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -1645,7 +1645,7 @@ func (c *ReposListForksCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateForkCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	Organization string `name:"organization" help:"Optional parameter to specify the organization name if forking into an organization."`
 }
@@ -1661,7 +1661,7 @@ func (c *ReposCreateForkCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListInvitationsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1679,7 +1679,7 @@ func (c *ReposListInvitationsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteInvitationCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	InvitationId int64  `required:"" name:"invitation_id"`
 }
@@ -1695,7 +1695,7 @@ func (c *ReposDeleteInvitationCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposUpdateInvitationCmd struct {
 	internal.BaseCmd
-	Owner        string `required:"" name:"owner"`
+	Owner        string `name:"owner"`
 	Repo         string `required:"" name:"repo"`
 	InvitationId int64  `required:"" name:"invitation_id"`
 	Permissions  string "name:\"permissions\" help:\"The permissions that the associated user will have on the repository. Valid values are `read`, `write`, and `admin`.\""
@@ -1751,7 +1751,7 @@ func (c *ReposDeclineInvitationCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposMergeCmd struct {
 	internal.BaseCmd
-	Owner         string `required:"" name:"owner"`
+	Owner         string `name:"owner"`
 	Repo          string `required:"" name:"repo"`
 	Base          string `required:"" name:"base" help:"The name of the base branch that the head will be merged into."`
 	Head          string `required:"" name:"head" help:"The head to merge. This can be a branch name or a commit SHA1."`
@@ -1772,7 +1772,7 @@ func (c *ReposMergeCmd) Run(isValueSetMap map[string]bool) error {
 type ReposGetPagesCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"**Note:** The GitHub Pages API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 }
 
@@ -1788,7 +1788,7 @@ func (c *ReposGetPagesCmd) Run(isValueSetMap map[string]bool) error {
 type ReposUpdateInformationAboutPagesSiteCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"**Note:** The GitHub Pages API on GitHub is currently available for developers to preview. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	Cname           string "name:\"cname\" help:\"Specify a custom domain for the repository. Sending a `null` value will remove the custom domain. For more about custom domains, see '[Using a custom domain with GitHub Pages](https://help.github.com/articles/using-a-custom-domain-with-github-pages/).'\""
 	Source          string "name:\"source\" help:\"Update the source for the repository. Must include the branch name, and may optionally specify the subdirectory `/docs`. Possible values are `'gh-pages'`, `'master'`, and `'master /docs'`.\""
@@ -1808,7 +1808,7 @@ func (c *ReposUpdateInformationAboutPagesSiteCmd) Run(isValueSetMap map[string]b
 type ReposRequestPageBuildCmd struct {
 	internal.BaseCmd
 	MisterFantastic bool   "name:\"mister-fantastic-preview\" required:\"\" help:\"This endpoint is currently available for developers to preview. During the preview period, the API may change without advance notice.\n\nTo access this endpoint during the preview period, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\n  application/vnd.github.mister-fantastic-preview+json\n\n```\""
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 }
 
@@ -1823,7 +1823,7 @@ func (c *ReposRequestPageBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListPagesBuildsCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1841,7 +1841,7 @@ func (c *ReposListPagesBuildsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetLatestPagesBuildCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1855,7 +1855,7 @@ func (c *ReposGetLatestPagesBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetPagesBuildCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	BuildId int64  `required:"" name:"build_id"`
 }
@@ -1871,7 +1871,7 @@ func (c *ReposGetPagesBuildCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListReleasesCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -1889,7 +1889,7 @@ func (c *ReposListReleasesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 }
@@ -1905,7 +1905,7 @@ func (c *ReposGetReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetLatestReleaseCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -1919,7 +1919,7 @@ func (c *ReposGetLatestReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetReleaseByTagCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Tag   string `required:"" name:"tag"`
 }
@@ -1935,7 +1935,7 @@ func (c *ReposGetReleaseByTagCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateReleaseCmd struct {
 	internal.BaseCmd
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	TagName         string `required:"" name:"tag_name" help:"The name of the tag."`
 	TargetCommitish string `name:"target_commitish" help:"Specifies the commitish value that determines where the Git tag is created from. Can be any branch or commit SHA. Unused if the Git tag already exists."`
@@ -1961,7 +1961,7 @@ func (c *ReposCreateReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditReleaseCmd struct {
 	internal.BaseCmd
-	Owner           string `required:"" name:"owner"`
+	Owner           string `name:"owner"`
 	Repo            string `required:"" name:"repo"`
 	ReleaseId       int64  `required:"" name:"release_id"`
 	TagName         string `name:"tag_name" help:"The name of the tag."`
@@ -1989,7 +1989,7 @@ func (c *ReposEditReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 }
@@ -2005,7 +2005,7 @@ func (c *ReposDeleteReleaseCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListAssetsForReleaseCmd struct {
 	internal.BaseCmd
-	Owner     string `required:"" name:"owner"`
+	Owner     string `name:"owner"`
 	Repo      string `required:"" name:"repo"`
 	ReleaseId int64  `required:"" name:"release_id"`
 	PerPage   int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -2025,7 +2025,7 @@ func (c *ReposListAssetsForReleaseCmd) Run(isValueSetMap map[string]bool) error 
 
 type ReposGetReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 }
@@ -2041,7 +2041,7 @@ func (c *ReposGetReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposEditReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 	Name    string `name:"name" help:"The file name of the asset."`
@@ -2061,7 +2061,7 @@ func (c *ReposEditReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteReleaseAssetCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	AssetId int64  `required:"" name:"asset_id"`
 }
@@ -2077,7 +2077,7 @@ func (c *ReposDeleteReleaseAssetCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetContributorsStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2091,7 +2091,7 @@ func (c *ReposGetContributorsStatsCmd) Run(isValueSetMap map[string]bool) error 
 
 type ReposGetCommitActivityStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2105,7 +2105,7 @@ func (c *ReposGetCommitActivityStatsCmd) Run(isValueSetMap map[string]bool) erro
 
 type ReposGetCodeFrequencyStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2119,7 +2119,7 @@ func (c *ReposGetCodeFrequencyStatsCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposGetParticipationStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2133,7 +2133,7 @@ func (c *ReposGetParticipationStatsCmd) Run(isValueSetMap map[string]bool) error
 
 type ReposGetPunchCardStatsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2147,7 +2147,7 @@ func (c *ReposGetPunchCardStatsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposCreateStatusCmd struct {
 	internal.BaseCmd
-	Owner       string `required:"" name:"owner"`
+	Owner       string `name:"owner"`
 	Repo        string `required:"" name:"repo"`
 	Sha         string `required:"" name:"sha"`
 	State       string "required:\"\" name:\"state\" help:\"The state of the status. Can be one of `error`, `failure`, `pending`, or `success`.\""
@@ -2171,7 +2171,7 @@ func (c *ReposCreateStatusCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListStatusesForRefCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	Ref     string `required:"" name:"ref"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
@@ -2191,7 +2191,7 @@ func (c *ReposListStatusesForRefCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetCombinedStatusForRefCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Ref   string `required:"" name:"ref"`
 }
@@ -2207,7 +2207,7 @@ func (c *ReposGetCombinedStatusForRefCmd) Run(isValueSetMap map[string]bool) err
 
 type ReposGetTopReferrersCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2221,7 +2221,7 @@ func (c *ReposGetTopReferrersCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetTopPathsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 }
 
@@ -2235,7 +2235,7 @@ func (c *ReposGetTopPathsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetViewsCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Per   string "name:\"per\" help:\"Must be one of: `day`, `week`.\""
 }
@@ -2251,7 +2251,7 @@ func (c *ReposGetViewsCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetClonesCmd struct {
 	internal.BaseCmd
-	Owner string `required:"" name:"owner"`
+	Owner string `name:"owner"`
 	Repo  string `required:"" name:"repo"`
 	Per   string "name:\"per\" help:\"Must be one of: `day`, `week`.\""
 }
@@ -2267,7 +2267,7 @@ func (c *ReposGetClonesCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposListHooksCmd struct {
 	internal.BaseCmd
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 	PerPage int64  `name:"per_page" help:"Results per page (max 100)"`
 	Page    int64  `name:"page" help:"Page number of the results to fetch."`
@@ -2285,7 +2285,7 @@ func (c *ReposListHooksCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposGetHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2301,7 +2301,7 @@ func (c *ReposGetHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposTestPushHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2317,7 +2317,7 @@ func (c *ReposTestPushHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposPingHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }
@@ -2333,7 +2333,7 @@ func (c *ReposPingHookCmd) Run(isValueSetMap map[string]bool) error {
 
 type ReposDeleteHookCmd struct {
 	internal.BaseCmd
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 	HookId int64  `required:"" name:"hook_id"`
 }

--- a/internal/generated/teamscmd.go
+++ b/internal/generated/teamscmd.go
@@ -178,7 +178,7 @@ type TeamsCheckManagesRepoCmd struct {
 	internal.BaseCmd
 	Hellcat bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
 	TeamId  int64  `required:"" name:"team_id"`
-	Owner   string `required:"" name:"owner"`
+	Owner   string `name:"owner"`
 	Repo    string `required:"" name:"repo"`
 }
 
@@ -196,7 +196,7 @@ type TeamsAddOrUpdateRepoCmd struct {
 	internal.BaseCmd
 	Hellcat    bool   "name:\"hellcat-preview\" help:\"**Note:** The Nested Teams API is currently available for developers to preview. See the [blog post](/changes/2017-08-30-preview-nested-teams) for full details. To access the API, you must provide a custom [media type](/v3/media) in the `Accept` header:\n\n```\napplication/vnd.github.hellcat-preview+json\n\n```\""
 	TeamId     int64  `required:"" name:"team_id"`
-	Owner      string `required:"" name:"owner"`
+	Owner      string `name:"owner"`
 	Repo       string `required:"" name:"repo"`
 	Permission string "name:\"permission\" help:\"The permission to grant the team on this repository. Can be one of:  \n\\* `pull` - team members can pull, but not push to or administer this repository.  \n\\* `push` - team members can pull and push, but not administer this repository.  \n\\* `admin` - team members can pull, push and administer this repository.  \n  \nIf no permission is specified, the team's `permission` attribute will be used to determine what permission to grant the team on this repository.  \n**Note**: If you pass the `hellcat-preview` media type, you can promote—but not demote—a `permission` attribute inherited through a parent team.\""
 }
@@ -215,7 +215,7 @@ func (c *TeamsAddOrUpdateRepoCmd) Run(isValueSetMap map[string]bool) error {
 type TeamsRemoveRepoCmd struct {
 	internal.BaseCmd
 	TeamId int64  `required:"" name:"team_id"`
-	Owner  string `required:"" name:"owner"`
+	Owner  string `name:"owner"`
 	Repo   string `required:"" name:"repo"`
 }
 


### PR DESCRIPTION
Most endpoints contain `/:owner/:repo`.  This allows both owner and repo to be set with `--repo owner/repo` instead of `--owner owner --repo repo`. The old way still works.  This just adds a shortcut.