### PR TITLE
README: simplify Homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,11 +148,10 @@ We did it! Scratch v0.0.2 is available for download.
 
 #### Homebrew
 
-To install with [homebrew](https://brew.sh/):
+To install with [Homebrew](https://brew.sh/) on macOS or Linux:
 
 ```
-brew tap octo-cli/octo
-brew install octo
+brew install octo-cli/octo/octo
 ```
 
 #### The easy and overly trusting way

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,11 +148,10 @@ We did it! Scratch v0.0.2 is available for download.
 
 #### Homebrew
 
-To install with [homebrew](https://brew.sh/):
+To install with [Homebrew](https://brew.sh/) on macOS or Linux:
 
 ```
-brew tap octo-cli/octo
-brew install octo
+brew install octo-cli/octo/octo
 ```
 
 #### The easy and overly trusting way


### PR DESCRIPTION
- capitalise "Homebrew"
- point out the Homebrew formula works on macOS or Linux
- use the one-liner installation format