### PR TITLE
add --ref=main to semver-next calls

### DIFF
--- a/script/tag-release
+++ b/script/tag-release
@@ -9,6 +9,7 @@ make -s bin/semver-next
 set +e
 
 bin/semver-next octo-cli/octo-cli \
+  --ref=main \
   --max-bump=MINOR \
   --require-labels \
   --require-change >/dev/null
@@ -28,6 +29,7 @@ set -e
 
 tg="$(
   bin/semver-next octo-cli/octo-cli \
+    --ref=main \
     --max-bump=MINOR \
     --require-labels \
     --require-change \


### PR DESCRIPTION
accommodates the default branch switch